### PR TITLE
docs: add GCP Cloud Run setup guide, API usage, and mini-tools migration guide

### DIFF
--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -1,0 +1,79 @@
+# market-info-api 使い方
+
+## ベース URL
+
+```
+https://market-info-api-619599800912.asia-northeast1.run.app
+```
+
+---
+
+## エンドポイント一覧
+
+### ヘルスチェック
+
+```
+GET /health
+→ {"status": "ok"}
+```
+
+### 株式ランキング
+
+```
+GET /ranking/manifest
+→ {"dates": ["2026-03-27", ...], "latest": "2026-03-27"}
+
+GET /ranking/{date}         # date: YYYY-MM-DD
+→ {"date": "2026-03-27", "records": [...]}
+```
+
+### 日経寄与度
+
+```
+GET /nikkei/manifest
+→ {"dates": [...], "latest_date": "2026-03-27", "generated_at": "..."}
+
+GET /nikkei/{date}          # date: YYYY-MM-DD
+→ {"date": "2026-03-27", "index": "nikkei225", "records": [...]}
+```
+
+### 株主優待
+
+```
+GET /yutai/manifest
+→ {"latest_month": "2026-12", "latest_path": "2026-12.json", "months": [...]}
+
+GET /yutai/monthly/{year_month}    # year_month: YYYY-MM
+→ {"year": 2026, "month": 12, "records": [...]}
+```
+
+---
+
+## キャッシュ
+
+| 種別 | TTL |
+|------|-----|
+| manifest | 5分 |
+| 日次データ | 60分 |
+
+---
+
+## 動作確認コマンド
+
+```bash
+curl https://market-info-api-619599800912.asia-northeast1.run.app/health
+curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/2026-03-27
+curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/2026-03-27
+curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/monthly/2026-12
+```
+
+---
+
+## OpenAPI ドキュメント
+
+```
+https://market-info-api-619599800912.asia-northeast1.run.app/docs
+```

--- a/docs/gcp-cloud-run-setup.md
+++ b/docs/gcp-cloud-run-setup.md
@@ -1,0 +1,117 @@
+# GCP Cloud Run セットアップ手順
+
+## なぜ GCP Cloud Run を選んだか
+
+| 候補 | 結論 | 理由 |
+|------|------|------|
+| Railway | 見送り | トライアル期間は $5 クレジットあり、終了後の永続無料枠は $1/月のみ。常時起動サービスでは数日で枯渇する |
+| Render | 見送り | 無料プランは15分無通信でスリープ、ping 等の workaround が必要 |
+| **GCP Cloud Run** | **採用** | 月200万リクエストまで永続無料枠あり、スリープなし、Dockerfile そのまま使える |
+
+Cloud Run は「リクエストがないときは課金されない（コールドスタートあり）」モデルで、mini-tools 程度のアクセス頻度では実質無料で運用できる。
+
+---
+
+## 前提
+
+- Google アカウント（個人）
+- GitHub リポジトリ: `Yuichi-TanakaJP/market-info-api`
+- GCP プロジェクト ID: `market-info-api`
+- プロジェクト番号: `619599800912`
+- リージョン: `asia-northeast1` (東京)
+- エンドポイント URL: `https://market-info-api-619599800912.asia-northeast1.run.app`
+
+## 料金
+
+- Cloud Run 永続無料枠: 月200万リクエストまで無料（トライアル終了後も継続）
+- 無料トライアル: $300 クレジット / 90日間
+- mini-tools 程度のアクセス頻度では無料枠を超えない見込み
+
+---
+
+## セットアップ手順
+
+### 1. GCP プロジェクト作成
+
+1. [console.cloud.google.com](https://console.cloud.google.com) にログイン
+2. **New Project** → プロジェクト名 `market-info-api` で作成
+
+### 2. Cloud Run サービス作成
+
+1. 左メニュー → **Cloud Run** → **サービス** → **サービスの作成**
+2. **「リポジトリから継続的にデプロイする」** を選択
+3. **Developer Connect** を選択 → **「Developer Connect で設定」**
+4. GitHub OAuth 認証 → `Yuichi-TanakaJP/market-info-api` のみ許可（Only select repositories）
+5. ビルド構成:
+   - ブランチ: `main`
+   - ビルドタイプ: `Dockerfile`
+   - ソースの場所: `/Dockerfile`
+
+### 3. サービス構成
+
+| 項目 | 設定値 |
+|------|--------|
+| サービス名 | `market-info-api` |
+| リージョン | `asia-northeast1 (東京)` |
+| 認証 | 公開アクセスを許可する |
+| 課金 | リクエストベース |
+| スケーリング | 自動（最小0、最大20） |
+| コンテナポート | `8000` |
+| メモリ | 512 MiB |
+| CPU | 1 |
+
+### 4. 環境変数
+
+「コンテナ、ネットワーキング、セキュリティ」→「変数とシークレット」タブで設定:
+
+| 変数名 | 値 |
+|--------|-----|
+| `R2_PUBLIC_BASE_URL` | `https://pub-b1f1de37018549c8a5ae3e6f9a7a1c6c.r2.dev` |
+
+---
+
+## 権限設定（ハマりポイント）
+
+### Cloud Build サービスアカウントへの権限付与
+
+ビルドが `IAM_PERMISSION_DENIED` で失敗する場合、以下の手順で修正する。
+
+**方法A: Build Trigger の画面から付与（推奨）**
+
+1. Cloud Run サービス → **「トリガー」タブ** 下部の **「build trigger」** リンク
+2. トリガー編集画面のソースセクションに黄色い警告が表示される
+3. **「すべて付与」** ボタンをクリック
+   - 対象: `service-619599800912@gcp-sa-cloudbuild.iam.gserviceaccount.com`
+   - 付与ロール: `roles/developerconnect.tokenAccessor`
+
+**方法B: IAM から手動付与**
+
+1. **「IAM と管理」→「IAM」**
+2. `service-619599800912@gcp-sa-cloudbuild.iam.gserviceaccount.com` を編集
+3. `Developer Connect 読み取りトークン アクセサー` ロールを追加
+
+### サービスアカウントの警告について
+
+トリガー編集画面に「このサービスアカウントには非常に幅広い権限が付与されている」という警告が出るが、**個人プロジェクトなので無視してよい**。チームや本番環境では最小権限のサービスアカウントを別途作成すること。
+
+---
+
+## ビルドの手動実行
+
+1. Cloud Run サービス → **「トリガー」タブ** → **「build trigger」**
+2. トリガー一覧でトリガー右の **「▶ 実行」** をクリック
+
+または、`main` ブランチに push すると自動でビルドが走る。
+
+---
+
+## 動作確認
+
+```bash
+curl https://market-info-api-619599800912.asia-northeast1.run.app/health
+# → {"status": "ok"}
+
+curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/manifest
+```

--- a/docs/mini-tools-migration.md
+++ b/docs/mini-tools-migration.md
@@ -1,0 +1,140 @@
+# mini-tools → market-info-api 移行手順
+
+## 概要
+
+現在 mini-tools は R2 に直接アクセスしてデータを取得している。
+これを market-info-api 経由に切り替えることで、キャッシュ・型保証・将来の認証が使えるようになる。
+
+market-info-api ベース URL:
+```
+https://market-info-api-619599800912.asia-northeast1.run.app
+```
+
+---
+
+## 現状と変更後の比較
+
+### stock-ranking
+
+**現状**
+- 環境変数 `STOCK_RANKING_DATA_BASE_URL` に R2 の URL を設定
+- `data-loader.ts` が `{baseUrl}/manifest.json` や `{baseUrl}/{fileKey}.json` を直接 fetch
+
+**変更後**
+- 環境変数 `STOCK_RANKING_DATA_BASE_URL` を削除（または空に）
+- 新しい環境変数 `MARKET_INFO_API_BASE_URL` を追加
+- `data-loader.ts` のフェッチ先を以下に変更:
+  - manifest: `{MARKET_INFO_API_BASE_URL}/ranking/manifest`
+  - 日次データ: `{MARKET_INFO_API_BASE_URL}/ranking/{date}` （`date` は YYYY-MM-DD 形式）
+
+**注意**: 現在の実装は `{fileKey}.json`（ハイフンなしの数字8桁）にアクセスしているが、
+API は `/ranking/{date}`（YYYY-MM-DD）を受け付け、内部でファイル名変換している。
+よって API に渡す日付は **YYYY-MM-DD 形式のまま**でよい。
+
+---
+
+### nikkei-contribution
+
+**現状**
+- 環境変数 `NIKKEI_CONTRIBUTION_DATA_BASE_URL` を参照（未設定時はハードコードされた R2 URL を使用）
+- `data-loader.ts` が `nikkei_contribution_manifest.json` や `nikkei_contribution_{date}.json` を直接 fetch
+
+**変更後**
+- 環境変数 `NIKKEI_CONTRIBUTION_DATA_BASE_URL` を削除
+- 新しい環境変数 `MARKET_INFO_API_BASE_URL` を追加（stock-ranking と共通）
+- `data-loader.ts` のフェッチ先を以下に変更:
+  - manifest: `{MARKET_INFO_API_BASE_URL}/nikkei/manifest`
+  - 日次データ: `{MARKET_INFO_API_BASE_URL}/nikkei/{date}` （YYYY-MM-DD 形式）
+
+**注意**: `data-loader.ts` にハードコードされたデフォルト R2 URL がある（6行目）。
+これを削除して環境変数のみに依存するよう修正が必要。
+
+---
+
+### yutai-candidates
+
+**現状**
+- 環境変数 `MONTHLY_YUTAI_DATA_BASE_URL` に R2 の manifest.json URL を設定
+- `data-loader.ts` が manifest を fetch してから月次データを fetch
+
+**変更後**
+- 環境変数 `MONTHLY_YUTAI_DATA_BASE_URL` を削除
+- 新しい環境変数 `MARKET_INFO_API_BASE_URL` を追加（他ツールと共通）
+- `data-loader.ts` のフェッチ先を以下に変更:
+  - manifest: `{MARKET_INFO_API_BASE_URL}/yutai/manifest`
+  - 月次データ: `{MARKET_INFO_API_BASE_URL}/yutai/monthly/{year_month}` （YYYY-MM 形式）
+
+**注意**: 現在の実装は manifest の `latest_path` を使って月次データの URL を組み立てているが、
+API 移行後は `latest_month` から直接 `/yutai/monthly/{latest_month}` で取得できる。
+`data-loader.ts` のロジックを大幅に簡略化できる。
+
+---
+
+## 環境変数の変更まとめ
+
+| 環境変数 | 変更 |
+|----------|------|
+| `STOCK_RANKING_DATA_BASE_URL` | 削除 |
+| `NIKKEI_CONTRIBUTION_DATA_BASE_URL` | 削除 |
+| `MONTHLY_YUTAI_DATA_BASE_URL` | 削除 |
+| `MARKET_INFO_API_BASE_URL` | **新規追加**: `https://market-info-api-619599800912.asia-northeast1.run.app` |
+
+Vercel の環境変数設定画面で上記を変更する。
+
+---
+
+## API レスポンス形式
+
+移行後に各 data-loader.ts が受け取るレスポンスの型。
+
+### `/ranking/manifest`
+```json
+{
+  "dates": ["2026-03-27", "2026-03-26", ...],
+  "latest": "2026-03-27"
+}
+```
+
+### `/ranking/{date}`
+```json
+{
+  "date": "2026-03-27",
+  "records": [...]
+}
+```
+
+### `/nikkei/manifest`
+```json
+{
+  "dates": ["2026-03-27", ...],
+  "latest_date": "2026-03-27",
+  "generated_at": "2026-03-27T..."
+}
+```
+
+### `/nikkei/{date}`
+```json
+{
+  "date": "2026-03-27",
+  "index": "nikkei225",
+  "records": [...]
+}
+```
+
+### `/yutai/manifest`
+```json
+{
+  "latest_month": "2026-12",
+  "latest_path": "2026-12.json",
+  "months": [{"year": 2026, "month": 12, "path": "2026-12.json", "count": 225}, ...]
+}
+```
+
+### `/yutai/monthly/{year_month}`
+```json
+{
+  "year": 2026,
+  "month": 12,
+  "records": [...]
+}
+```


### PR DESCRIPTION
## Summary

- GCP Cloud Run セットアップ手順（Railway/Render との比較・採用理由含む）
- API エンドポイント一覧・動作確認コマンド
- mini-tools 側の移行手順（data-loader.ts 3ファイルの変更方針・環境変数まとめ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)