### PR TITLE
feat: add TOPIX33 API routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import health, nikkei, ranking, yutai
+from app.routers import health, nikkei, ranking, topix33, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -13,4 +13,5 @@ app = FastAPI(
 app.include_router(health.router)
 app.include_router(ranking.router)
 app.include_router(nikkei.router)
+app.include_router(topix33.router)
 app.include_router(yutai.router)

--- a/app/routers/topix33.py
+++ b/app/routers/topix33.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app import cache, r2
+
+router = APIRouter(prefix="/topix33", tags=["topix33"])
+
+_PREFIX = "topix33"
+_MANIFEST_FILE = "topix33_manifest.json"
+
+
+@router.get("/manifest")
+async def get_manifest() -> dict:
+    """topix33_manifest.json を返す。latest_date で最新日付がわかる。"""
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/manifest",
+            lambda: r2.fetch_json(f"{_PREFIX}/{_MANIFEST_FILE}"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get("/{date}")
+async def get_day(date: str) -> dict:
+    """YYYY-MM-DD 形式の日付に対応する TOPIX33 日次 JSON を返す。"""
+    file_name = f"topix33_{date}.json"
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{date}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{file_name}"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail=f"topix33 not found: {date}") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -37,6 +37,24 @@ GET /nikkei/{date}          # date: YYYY-MM-DD
 → {"date": "2026-03-27", "index": "nikkei225", "records": [...]}
 ```
 
+### TOPIX33
+
+```
+GET /topix33/manifest
+→ {"dates": [...], "latest_date": "2026-04-01", "generated_at": "..."}
+
+GET /topix33/{date}         # date: YYYY-MM-DD
+→ {
+    "date": "2026-04-01",
+    "index": "topix33",
+    "generated_at": "...",
+    "summary": {"advancers": 20, "decliners": 12, "unchanged": 1},
+    "top_positive": [...],
+    "top_negative": [...],
+    "sectors": [...]
+  }
+```
+
 ### 株主優待
 
 ```
@@ -66,6 +84,8 @@ curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/manife
 curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/2026-03-27
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/2026-03-27
+curl https://market-info-api-619599800912.asia-northeast1.run.app/topix33/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/topix33/2026-04-01
 curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/monthly/2026-12
 ```

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -16,9 +16,11 @@ def client(monkeypatch):
     importlib.reload(r2_mod)
     import app.routers.ranking as ranking_mod
     import app.routers.nikkei as nikkei_mod
+    import app.routers.topix33 as topix33_mod
     import app.routers.yutai as yutai_mod
     importlib.reload(ranking_mod)
     importlib.reload(nikkei_mod)
+    importlib.reload(topix33_mod)
     importlib.reload(yutai_mod)
     from app.main import app
     return TestClient(app)
@@ -60,6 +62,29 @@ def test_nikkei_day(client):
         resp = client.get("/nikkei/2026-03-28")
     assert resp.status_code == 200
     assert resp.json()["date"] == "2026-03-28"
+
+
+def test_topix33_manifest(client):
+    manifest = {"dates": ["2026-04-01"], "latest_date": "2026-04-01", "generated_at": ""}
+    with patch("app.routers.topix33.cache.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get("/topix33/manifest")
+    assert resp.status_code == 200
+    assert resp.json()["latest_date"] == "2026-04-01"
+
+
+def test_topix33_day(client):
+    day = {
+        "date": "2026-04-01",
+        "index": "topix33",
+        "summary": {"advancers": 20, "decliners": 12, "unchanged": 1},
+        "top_positive": [],
+        "top_negative": [],
+        "sectors": [],
+    }
+    with patch("app.routers.topix33.cache.get_day", new=AsyncMock(return_value=day)):
+        resp = client.get("/topix33/2026-04-01")
+    assert resp.status_code == 200
+    assert resp.json()["index"] == "topix33"
 
 
 def test_yutai_manifest(client):


### PR DESCRIPTION
## Summary

- add TOPIX33 manifest/day API routes following the existing thin R2 proxy pattern
- register the new router in the FastAPI app
- extend router unit tests and API usage docs

## Verification

- `codex review --uncommitted`
  - no substantive findings
- `.\.venv\Scripts\python.exe -m pytest tests\test_routers_unit.py -q`
  - `9 passed`
