### PR TITLE
feat(nikko): GET /nikko/credit エンドポイントを追加

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import health, nikkei, ranking, topix33, yutai
+from app.routers import health, nikkei, nikko, ranking, topix33, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -13,5 +13,6 @@ app = FastAPI(
 app.include_router(health.router)
 app.include_router(ranking.router)
 app.include_router(nikkei.router)
+app.include_router(nikko.router)
 app.include_router(topix33.router)
 app.include_router(yutai.router)

--- a/app/routers/nikko.py
+++ b/app/routers/nikko.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app import cache, r2
+
+router = APIRouter(prefix="/nikko", tags=["nikko"])
+
+_CREDIT_KEY = "nikko/credit/latest.json"
+
+
+@router.get("/credit")
+async def get_credit() -> dict:
+    """日興証券の信用取引取扱銘柄情報を返す。
+
+    by_code 辞書形式で返すので、クライアントは by_code[code] でO(1)参照できる。
+    """
+    try:
+        return await cache.get_manifest(
+            "nikko/credit",
+            lambda: r2.fetch_json(_CREDIT_KEY),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc


### PR DESCRIPTION
## Summary
- `app/routers/nikko.py` 新規作成: `GET /nikko/credit` エンドポイント
- `app/main.py`: nikkoルーターを登録

## レスポンス形式
```json
{
  "date": "2026-04-04",
  "generated_at": "2026-04-04T12:00:00+09:00",
  "record_count": 4243,
  "by_code": {
    "1301": {
      "institutional_buy": true,
      "institutional_short": true,
      "general_buy": true,
      "general_short": true,
      "available_shares": 900
    }
  }
}
```

R2の `nikko/credit/latest.json` をfetchして返す。キャッシュTTL 5分。

## Test plan
- [ ] market_info側でpublishを実行後、`GET /nikko/credit` が正しいレスポンスを返すことを確認
- [ ] R2未アップロード時に502が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)