### PR TITLE
fix: ci.yml の CRLF を LF に修正し .gitattributes を追加する

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.yml text eol=lf
+*.yaml text eol=lf
+*.py text eol=lf


### PR DESCRIPTION
## Summary

- Windows 環境で Git が ci.yml を CRLF に変換し、VSCode の YAML パーサーがエラーを出していた問題を修正
- `.gitattributes` を追加して yml / py ファイルを LF 固定にする

## Test plan

- [ ] CI が green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)