### PR TITLE
feat: add /us-ranking router for US stock ranking

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, topix33, yutai
+from app.routers import earnings_calendar, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -27,3 +27,4 @@ app.include_router(market_calendar.router)
 app.include_router(topix33.router)
 app.include_router(yutai.router)
 app.include_router(market_rankings.router)
+app.include_router(us_ranking.router)

--- a/app/routers/us_ranking.py
+++ b/app/routers/us_ranking.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/us-ranking", tags=["us-ranking"])
+
+_PREFIX = "us-stock-ranking"
+
+
+class UsRankingManifest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    dates: list[str]
+    latest: str
+
+
+class UsRankingRecord(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    exchange: str
+    ranking: str
+    rank: int
+    ticker: str
+    listingExchange: str
+    handlingFlag: str | None = None
+    name: str
+    nameEn: str | None = None
+    price: float
+    time: str
+    change: float
+    changeRate: float
+    volume: float | None = None
+    tradedValue: float | None = None
+    per: float | None = None
+    pbr: float | None = None
+
+
+class UsRankingDay(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    date: str
+    records: list[UsRankingRecord]
+
+
+@router.get(
+    "/manifest",
+    response_model=UsRankingManifest,
+    summary="米国株ランキング manifest を取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_manifest() -> dict:
+    """manifest.json を返す。
+
+    - `latest`: 最新日付（YYYY-MM-DD）
+    - `dates`: 利用可能な日付の降順リスト
+
+    更新単位: 営業日ごと（market_info の日次バッチ完了後に R2 へ publish される）。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/manifest",
+            lambda: r2.fetch_json(f"{_PREFIX}/manifest.json"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/{date}",
+    response_model=UsRankingDay,
+    summary="指定日の米国株ランキング JSON を取得",
+    responses={
+        404: {"description": "指定日のデータが R2 に存在しない（休場日・未来日・バッチ未実行日）"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_day(date: str) -> dict:
+    """YYYY-MM-DD 形式の日付に対応する日次ランキング JSON を返す。
+
+    - `date`: 対象日（YYYY-MM-DD）
+    - `records`: 銘柄ごとのランキングデータ配列（exchange / ranking / rank / ticker ほか）
+
+    404 の場合: 休場日・未来日・バッチ未実行日のいずれか。
+    mini-tools 側は manifest の `dates` に含まれる日付のみリクエストすること。
+    """
+    file_key = date.replace("-", "")
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{file_key}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{file_key}.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail=f"us-ranking not found: {date}") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc


### PR DESCRIPTION
## Summary

- `GET /us-ranking/manifest` → R2 `us-stock-ranking/manifest.json`
- `GET /us-ranking/{date}` → R2 `us-stock-ranking/{YYYYMMDD}.json`（YYYY-MM-DD → YYYYMMDD 変換）
- `UsRankingManifest` / `UsRankingRecord` / `UsRankingDay` の Pydantic モデル追加
- `app/main.py` に `us_ranking.router` を登録

## Test plan

- [ ] `GET /us-ranking/manifest` が 200 を返すこと
- [ ] `GET /us-ranking/2026-04-10` が正しい日次データを返すこと
- [ ] 存在しない日付で 404 が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)