### PR TITLE
feat: add /edinet/document-list router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, topix33, us_ranking, yutai
+from app.routers import earnings_calendar, edinet, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -28,3 +28,4 @@ app.include_router(topix33.router)
 app.include_router(yutai.router)
 app.include_router(market_rankings.router)
 app.include_router(us_ranking.router)
+app.include_router(edinet.router)

--- a/app/routers/edinet.py
+++ b/app/routers/edinet.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/edinet", tags=["edinet"])
+
+_PREFIX = "edinet/document-list"
+
+
+class EdinetItem(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    doc_id: str
+    submit_datetime: str | None
+    edinet_code: str | None
+    sec_code: str | None
+    filer_name: str | None
+    doc_type_code: str | None
+    doc_description: str | None
+    has_xbrl: bool
+    has_pdf: bool
+    has_csv: bool
+
+
+class EdinetDocumentList(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    as_of_date: str
+    total_count: int
+    items: list[EdinetItem]
+
+
+@router.get(
+    "/document-list/latest",
+    response_model=EdinetDocumentList,
+    summary="EDINET書類一覧（最新）を取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_latest() -> dict:
+    """最新日の EDINET 提出書類一覧を返す。
+
+    - `as_of_date`: データの対象日（YYYY-MM-DD）
+    - `total_count`: 提出書類の総件数
+    - `items`: 書類エントリの配列
+
+    更新単位: 日次（平日）。週末・祝日は件数 0 になる場合がある。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/latest",
+            lambda: r2.fetch_json(f"{_PREFIX}/latest.json"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/document-list/{date}",
+    response_model=EdinetDocumentList,
+    summary="EDINET書類一覧（日付指定）を取得",
+    responses={
+        404: {"description": "指定日のデータが R2 に存在しない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_by_date(date: str) -> dict:
+    """YYYY-MM-DD 形式の日付に対応する EDINET 提出書類一覧を返す。
+
+    404 の場合: 指定日のデータが存在しない（未取得日・休日など）。
+    """
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{date}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{date}.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail=f"edinet document-list not found: {date}") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -495,3 +495,72 @@ def test_dividend_yield_manifest_502(client):
     with patch("app.routers.market_rankings.cache.get_manifest", new=AsyncMock(side_effect=err)):
         resp = client.get("/market-rankings/dividend-yield/manifest")
     assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# edinet
+# ---------------------------------------------------------------------------
+
+_EDINET_PAYLOAD = {
+    "as_of_date": "2026-04-23",
+    "total_count": 2,
+    "items": [
+        {
+            "doc_id": "S100ABCD",
+            "submit_datetime": "2026-04-23 09:00",
+            "edinet_code": "E00001",
+            "sec_code": "1234",
+            "filer_name": "テスト株式会社",
+            "doc_type_code": "120",
+            "doc_description": "有価証券報告書－第1期",
+            "has_xbrl": True,
+            "has_pdf": True,
+            "has_csv": True,
+        },
+        {
+            "doc_id": "S100EFGH",
+            "submit_datetime": "2026-04-23 10:00",
+            "edinet_code": "E00002",
+            "sec_code": None,
+            "filer_name": "テスト投資信託",
+            "doc_type_code": "010",
+            "doc_description": "有価証券届出書",
+            "has_xbrl": False,
+            "has_pdf": True,
+            "has_csv": False,
+        },
+    ],
+}
+
+
+def test_edinet_document_list_latest(client):
+    with patch("app.routers.edinet.cache.get_manifest", new=AsyncMock(return_value=_EDINET_PAYLOAD)):
+        resp = client.get("/edinet/document-list/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["as_of_date"] == "2026-04-23"
+    assert data["total_count"] == 2
+    assert data["items"][0]["doc_id"] == "S100ABCD"
+    assert data["items"][1]["sec_code"] is None
+
+
+def test_edinet_document_list_by_date(client):
+    with patch("app.routers.edinet.cache.get_day", new=AsyncMock(return_value=_EDINET_PAYLOAD)):
+        resp = client.get("/edinet/document-list/2026-04-23")
+    assert resp.status_code == 200
+    assert resp.json()["as_of_date"] == "2026-04-23"
+
+
+def test_edinet_document_list_by_date_not_found(client):
+    err = _make_http_error("https://r2.example.com/edinet/document-list/2026-01-01.json", 404)
+    with patch("app.routers.edinet.cache.get_day", new=AsyncMock(side_effect=err)):
+        resp = client.get("/edinet/document-list/2026-01-01")
+    assert resp.status_code == 404
+    assert "2026-01-01" in resp.json()["detail"]
+
+
+def test_edinet_document_list_latest_502(client):
+    err = _make_http_error("https://r2.example.com/edinet/document-list/latest.json", 500)
+    with patch("app.routers.edinet.cache.get_manifest", new=AsyncMock(side_effect=err)):
+        resp = client.get("/edinet/document-list/latest")
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary

- `GET /edinet/document-list/latest` — 最新日の EDINET 書類一覧を返す
- `GET /edinet/document-list/{date}` — 日付指定（YYYY-MM-DD）の書類一覧を返す
- `EdinetDocumentList` / `EdinetItem` response model 追加
- 404（指定日データなし）・502（R2 取得失敗）エラー変換

## Test plan

- [x] unit tests 4件（latest / by_date / 404 / 502）全パス
- [x] 全43テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)