### PR TITLE
fix: add econ-calendar to README and update cache TTL values

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /nikko/credit` | 日興証券 信用取引取扱銘柄一覧 |
 | `GET /yutai/manifest` | 優待データ manifest |
 | `GET /yutai/monthly/{year_month}` | 指定月の優待データ |
+| `GET /econ-calendar/weekly` | 今週の経済指標カレンダー |
+| `GET /econ-calendar/weekly/meta` | 経済指標カレンダー更新メタ情報 |
 
 ---
 
@@ -82,7 +84,8 @@ curl http://localhost:8000/market-calendar/us-closed
 
 | 種別 | TTL |
 |------|-----|
-| manifest 系 | 5 分 |
-| 日次・月次データ | 60 分 |
+| 可変データ（latest / manifest 系） | 6 時間 |
+| 不変データ（過去日次・月次） | 24 時間 |
 
-インプロセスキャッシュのため、デプロイ（再起動）でリセットされる。
+インプロセスキャッシュのため、デプロイ（再起動）でリセットされる。  
+TTL 設計ルールの詳細は [`docs/api-contract.md`](docs/api-contract.md) を参照。


### PR DESCRIPTION
## Summary

- エンドポイント一覧に `/econ-calendar/weekly` と `/econ-calendar/weekly/meta` を追記
- キャッシュ表の TTL を旧値（5分/60分）から正しい値（6時間/24時間）に更新
- 可変/不変の表記と `docs/api-contract.md` への参照リンクを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)