### PR TITLE
docs: fill missing endpoints and add AGENTS.md / docs/README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md — market-info-api
+
+AI エージェント（Codex / Claude Code など）がこのリポジトリで作業する際の規則。
+
+---
+
+## 黄金律
+
+1. **推測しない** — コードや既存ドキュメントで確認できないことは書かない・変えない
+2. **変更は最小限・安全** — 必要な箇所だけ変える。副作用の広いリファクタはしない
+3. **エンドポイント仕様の一次情報源は `/docs`（OpenAPI）** — response_model・summary・docstring を優先し、docs/ はそれを補足する
+4. **認証情報を出力しない** — `.env` の値・API キーは絶対に表示・ログ出力しない
+
+---
+
+## ドキュメント記述ルール
+
+### api-contract.md に書くもの
+- エラーコードの意味と mini-tools 側の対応
+- TTL 設計ルール・設計根拠
+- manifest 形式の差異（endpoint グループ間のバリエーション）
+- インシデント記録と再発防止策
+- 認証の現状と将来構想
+
+### api-usage.md に書くもの
+- エンドポイント別のレスポンス例（実物に近い形）
+- curl コマンド集
+- キャッシュ TTL の参照表（api-contract.md の設計ルールと整合させること）
+
+### README.md / docs/README.md に書くもの
+- README.md: プロジェクト概要・エンドポイント一覧・起動方法・環境変数
+- docs/README.md: ドキュメント一覧と配置ルールのみ
+
+### 書いてはいけないもの
+- 調査ログ・作業メモ（git commit message か PR description に書く）
+- 廃止済みの仕様（削除して git history に任せる）
+
+---
+
+## コード変更ルール
+
+### response_model の変更
+- `market_info` が実際に publish する JSON の shape と一致させること
+- 簡略化した型（`list[str]` など）は使わない
+- nullable フィールドは `T | None` で明示する
+- 変更前に `tests/` のフィクスチャが実 payload shape を反映しているか確認する
+
+### キャッシュ
+- TTL 値は `app/cache.py` の `_MANIFEST_TTL`（21600秒=6時間）/ `_DAY_TTL`（86400秒=24時間）で一元管理する
+- router で直接数値を書かない
+
+### テスト
+- router unit test は `tests/fixtures/` の実 artifact shape（real_shape）を使う回帰ケースを必ず含める
+- 簡略 mock だけで終わらせない
+
+### 新しいエンドポイントを追加する場合
+1. `app/routers/` に router ファイルを追加
+2. `app/main.py` に `include_router` を追記
+3. `docs/api-contract.md` の「更新単位」テーブルに追記
+4. `docs/api-usage.md` にレスポンス例と curl コマンドを追記
+5. `README.md` のエンドポイント一覧に追記
+6. `tests/` にフィクスチャと回帰テストを追加
+
+---
+
+## Git / PR ルール
+
+- **main への直接コミット・プッシュ禁止**
+- バグ修正・動作変更は必ず PR を経由する
+- 小さなドキュメント修正のみ、かつオーナーが明示的に許可した場合に限り PR を省略できる
+- PR 前に `ruff check .` と `pytest` が通ることを確認する
+
+---
+
+## デプロイ
+
+- main へのマージで GCP Cloud Run が自動デプロイされる
+- 設定変更（環境変数・スケール）は Cloud Run コンソールで行う
+- 詳細は [`docs/gcp-cloud-run-setup.md`](docs/gcp-cloud-run-setup.md) を参照

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /nikko/credit` | 日興証券 信用取引取扱銘柄一覧 |
 | `GET /yutai/manifest` | 優待データ manifest |
 | `GET /yutai/monthly/{year_month}` | 指定月の優待データ |
+| `GET /us-ranking/manifest` | 米国株ランキング manifest |
+| `GET /us-ranking/{date}` | 指定日の米国株ランキング JSON |
+| `GET /market-rankings/market-cap/manifest` | 時価総額ランキング manifest |
+| `GET /market-rankings/market-cap/monthly/{year_month}` | 指定月の時価総額ランキング |
+| `GET /market-rankings/dividend-yield/manifest` | 配当利回りランキング manifest |
+| `GET /market-rankings/dividend-yield/monthly/{year_month}` | 指定月の配当利回りランキング |
+| `GET /edinet/document-list/latest` | EDINET 書類一覧（最新） |
+| `GET /edinet/document-list/{date}` | 指定日の EDINET 書類一覧 |
 | `GET /econ-calendar/weekly` | 今週の経済指標カレンダー |
 | `GET /econ-calendar/weekly/meta` | 経済指標カレンダー更新メタ情報 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# docs/
+
+market-info-api のドキュメント置き場。
+
+エンドポイント仕様の一次情報源は **`/docs`（OpenAPI）**。  
+このディレクトリには OpenAPI では表現しにくい事項や運用手順を補記する。
+
+---
+
+## ドキュメント一覧
+
+| ファイル | 内容 |
+|----------|------|
+| [api-contract.md](api-contract.md) | エラーコード・fallback 設計・TTL ルール・更新単位・manifest 形式・インシデント記録 |
+| [api-usage.md](api-usage.md) | エンドポイント別レスポンス例・curl コマンド集 |
+| [gcp-cloud-run-setup.md](gcp-cloud-run-setup.md) | GCP Cloud Run へのデプロイ手順（初期セットアップ・CI 連携） |
+| [mini-tools-migration.md](mini-tools-migration.md) | mini-tools が直接 R2 アクセスから API 経由に切り替える際のマイグレーション手順 |
+
+---
+
+## 配置ルール
+
+| 置く場所 | 内容 |
+|----------|------|
+| `docs/` | API 仕様・運用・デプロイ・migration ガイド |
+| `app/` | 実装コード（仕様の一次情報源は OpenAPI） |
+
+「なぜこの TTL にしたか」「なぜこの Pydantic 型か」などの **設計根拠** は `api-contract.md` に追記する。  
+調査ログや廃止済みの設計メモは `docs/` に残さず git history で参照すること。

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -156,7 +156,18 @@ GET /us-ranking/{date}         # date: YYYY-MM-DD
         "ranking": "volume",
         "rank": 1,
         "ticker": "NVDA",
-        ...
+        "listingExchange": "NASDAQ",
+        "handlingFlag": null,
+        "name": "エヌビディア",
+        "nameEn": "NVIDIA Corp",
+        "price": 875.4,
+        "time": "16:00",
+        "change": 12.3,
+        "changeRate": 1.42,
+        "volume": 45000000.0,
+        "tradedValue": null,
+        "per": null,
+        "pbr": null
       }
     ]
   }
@@ -172,11 +183,12 @@ GET /sbi/credit/latest
     "record_count": 1234,
     "by_code": {
       "1234": {
-        "position_status": "...",
-        "unit_upper_limit": "...",
+        "position_status": "可能",
+        "unit_upper_limit": "3000",
         "is_hyper": false,
         "is_daily": true,
-        "is_short": false
+        "is_short": false,
+        "is_long": true
       }
     }
   }
@@ -189,7 +201,29 @@ GET /sbi/credit/monthly/{year_month}    # year_month: YYYY-MM
 
 ```
 GET /earnings-calendar/overseas/latest
-→ {"as_of_date": "...", "records": [...]}
+→ {
+    "as_of_date": "2026-04-28",
+    "calendar": [
+      {
+        "date": "2026-04-29",
+        "count": 3,
+        "detail_status": "full",
+        "items": [
+          {
+            "event_id": "EV001",
+            "local_time": "16:00",
+            "ticker": "AAPL",
+            "stock_name": "Apple Inc",
+            "exchange_code": "NASDAQ",
+            "fiscal_term": "2026Q1",
+            "fiscal_term_name": "2026年第1四半期",
+            "sch_flg": "1",
+            "country_code": "US"
+          }
+        ]
+      }
+    ]
+  }
 
 GET /earnings-calendar/overseas/manifest
 → {
@@ -199,16 +233,37 @@ GET /earnings-calendar/overseas/manifest
   }
 
 GET /earnings-calendar/overseas/monthly/{year_month}    # year_month: YYYY-MM
-→ {"as_of_date": "...", "records": [...]}
+→ （same shape as /earnings-calendar/overseas/latest）
 
 GET /earnings-calendar/domestic/latest
-→ {"as_of_date": "...", "records": [...]}
+→ {
+    "as_of_date": "2026-04-28",
+    "calendar": [
+      {
+        "date": "2026-04-29",
+        "count": 5,
+        "detail_status": "full",
+        "items": [
+          {
+            "event_id": "EV002",
+            "time": "15:30",
+            "code": "7203",
+            "name": "トヨタ自動車",
+            "market": "プライム",
+            "announcement_type": "本決算",
+            "publish_status": "確定",
+            "progress_status": "発表済"
+          }
+        ]
+      }
+    ]
+  }
 
 GET /earnings-calendar/domestic/manifest
 → （same shape as overseas manifest）
 
 GET /earnings-calendar/domestic/monthly/{year_month}    # year_month: YYYY-MM
-→ {"as_of_date": "...", "records": [...]}
+→ （same shape as /earnings-calendar/domestic/latest）
 ```
 
 ### マーケットランキング
@@ -220,10 +275,27 @@ GET /market-rankings/market-cap/manifest
 GET /market-rankings/market-cap/monthly/{year_month}    # year_month: YYYY-MM
 → {
     "month": "2026-04",
+    "generatedAt": "2026-04-30T01:00:00Z",
     "markets": {
-      "prime": [...],
-      "standard": [...],
-      "growth": [...]
+      "prime": {
+        "date": "2026-04-30",
+        "records": [
+          {
+            "rank": 1,
+            "code": "7203",
+            "name": "トヨタ自動車",
+            "industry": "輸送用機器",
+            "marketCapOkuYen": 350000.0,
+            "price": 2800.0,
+            "priceTime": "2026-04-30T15:30:00",
+            "changeAmount": 30.0,
+            "changeRate": 1.08,
+            "dividendYieldPct": null
+          }
+        ]
+      },
+      "standard": {"date": "2026-04-30", "records": [...]},
+      "growth": {"date": "2026-04-30", "records": [...]}
     }
   }
 
@@ -246,7 +318,13 @@ GET /edinet/document-list/latest
         "doc_id": "S100XXXX",
         "submit_datetime": "2026-04-28T09:00:00",
         "edinet_code": "E12345",
-        ...
+        "sec_code": "72030",
+        "filer_name": "トヨタ自動車株式会社",
+        "doc_type_code": "120",
+        "doc_description": "有価証券報告書",
+        "has_xbrl": true,
+        "has_pdf": true,
+        "has_csv": false
       }
     ]
   }

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -141,6 +141,120 @@ GET /nikko/credit
   }
 ```
 
+### 株式ランキング（米国）
+
+```
+GET /us-ranking/manifest
+→ {"dates": ["2026-04-28", ...], "latest": "2026-04-28"}
+
+GET /us-ranking/{date}         # date: YYYY-MM-DD
+→ {
+    "date": "2026-04-28",
+    "records": [
+      {
+        "exchange": "NYSE",
+        "ranking": "volume",
+        "rank": 1,
+        "ticker": "NVDA",
+        ...
+      }
+    ]
+  }
+```
+
+### SBI 信用
+
+```
+GET /sbi/credit/latest
+→ {
+    "date": "2026-04-25",
+    "generated_at": "...",
+    "record_count": 1234,
+    "by_code": {
+      "1234": {
+        "position_status": "...",
+        "unit_upper_limit": "...",
+        "is_hyper": false,
+        "is_daily": true,
+        "is_short": false
+      }
+    }
+  }
+
+GET /sbi/credit/monthly/{year_month}    # year_month: YYYY-MM
+→ （same shape as /sbi/credit/latest）
+```
+
+### 決算カレンダー
+
+```
+GET /earnings-calendar/overseas/latest
+→ {"as_of_date": "...", "records": [...]}
+
+GET /earnings-calendar/overseas/manifest
+→ {
+    "as_of_date": "2026-04-28",
+    "current_window": {"from": "2026-04-01", "to": "2026-06-30"},
+    "months": [{"id": "2026-04", "year": 2026, "month": 4, "path": "monthly/2026-04.json", "partial": false, "bucket": "current"}, ...]
+  }
+
+GET /earnings-calendar/overseas/monthly/{year_month}    # year_month: YYYY-MM
+→ {"as_of_date": "...", "records": [...]}
+
+GET /earnings-calendar/domestic/latest
+→ {"as_of_date": "...", "records": [...]}
+
+GET /earnings-calendar/domestic/manifest
+→ （same shape as overseas manifest）
+
+GET /earnings-calendar/domestic/monthly/{year_month}    # year_month: YYYY-MM
+→ {"as_of_date": "...", "records": [...]}
+```
+
+### マーケットランキング
+
+```
+GET /market-rankings/market-cap/manifest
+→ {"latest": "2026-04", "months": ["2026-04", ...], "generatedAt": "..."}
+
+GET /market-rankings/market-cap/monthly/{year_month}    # year_month: YYYY-MM
+→ {
+    "month": "2026-04",
+    "markets": {
+      "prime": [...],
+      "standard": [...],
+      "growth": [...]
+    }
+  }
+
+GET /market-rankings/dividend-yield/manifest
+→ （same shape as market-cap manifest）
+
+GET /market-rankings/dividend-yield/monthly/{year_month}    # year_month: YYYY-MM
+→ （same shape as market-cap monthly）
+```
+
+### EDINET書類一覧
+
+```
+GET /edinet/document-list/latest
+→ {
+    "as_of_date": "2026-04-28",
+    "total_count": 42,
+    "items": [
+      {
+        "doc_id": "S100XXXX",
+        "submit_datetime": "2026-04-28T09:00:00",
+        "edinet_code": "E12345",
+        ...
+      }
+    ]
+  }
+
+GET /edinet/document-list/{date}    # date: YYYY-MM-DD
+→ （same shape as /edinet/document-list/latest）
+```
+
 ### JPX休場日
 
 ```
@@ -175,8 +289,8 @@ GET /market-calendar/us-closed
 
 | 種別 | TTL | 対象の例 |
 |------|-----|---------|
-| manifest / latest 系 | 5分 | `/econ-calendar/weekly`, `*/manifest`, `*/latest` |
-| 日次・月次データ | 60分 | `*/YYYY-MM-DD`, `*/monthly/YYYY-MM` |
+| manifest / latest 系 | 6時間 | `/econ-calendar/weekly`, `*/manifest`, `*/latest` |
+| 日次・月次データ | 24時間 | `*/YYYY-MM-DD`, `*/monthly/YYYY-MM` |
 
 ## 関連環境変数
 
@@ -201,6 +315,13 @@ curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/monthly/
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikko/credit
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-calendar/jpx-closed
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-calendar/us-closed
+curl https://market-info-api-619599800912.asia-northeast1.run.app/us-ranking/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/sbi/credit/latest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/earnings-calendar/domestic/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/earnings-calendar/overseas/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/market-rankings/market-cap/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/market-rankings/dividend-yield/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/edinet/document-list/latest
 ```
 
 `/market-calendar/jpx-closed` は `market_closed/jpx_market_closed_latest.json` を固定参照する。


### PR DESCRIPTION
## Summary

- `api-usage.md`: 実装済みだったが未記載だった5エンドポイントグループ（us-ranking / sbi/credit / earnings-calendar / market-rankings / edinet）を追加
- `api-usage.md`: キャッシュ TTL の誤った値を修正（5分/60分 → 6時間/24時間）
- `README.md`: エンドポイント一覧に us-ranking・market-rankings を追加
- `docs/README.md`: ドキュメント一覧・配置ルールの新規追加
- `AGENTS.md`: AI エージェント向けの作業規則を新規追加

## 確認事項

- [ ] api-usage.md のレスポンス例が実際の payload shape と整合しているか確認
- [ ] AGENTS.md の内容でプロジェクトポリシーと齟齬がないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)