### PR TITLE
feat: add GET /edinet/document-list/manifest endpoint

### DIFF
--- a/app/routers/edinet.py
+++ b/app/routers/edinet.py
@@ -34,6 +34,11 @@ class EdinetDocumentList(BaseModel):
     items: list[EdinetItem]
 
 
+class EdinetManifest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    dates: list[str]
+
+
 @router.get(
     "/document-list/latest",
     response_model=EdinetDocumentList,
@@ -53,6 +58,28 @@ async def get_latest() -> dict:
         return await cache.get_manifest(
             f"{_PREFIX}/latest",
             lambda: r2.fetch_json(f"{_PREFIX}/latest.json"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/document-list/manifest",
+    response_model=EdinetManifest,
+    summary="EDINET書類一覧 manifest を取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_manifest() -> dict:
+    """データが存在する日付の一覧を返す。
+
+    - `dates`: total_count > 0 の日付文字列配列（YYYY-MM-DD、昇順）
+
+    キャッシュ TTL: 6時間（可変）。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/manifest",
+            lambda: r2.fetch_json(f"{_PREFIX}/manifest.json"),
         )
     except Exception as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -632,6 +632,21 @@ def test_edinet_document_list_latest_502(client):
     assert resp.status_code == 502
 
 
+def test_edinet_document_list_manifest(client):
+    manifest = {"dates": ["2026-04-21", "2026-04-22", "2026-04-23"]}
+    with patch("app.routers.edinet.cache.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get("/edinet/document-list/manifest")
+    assert resp.status_code == 200
+    assert resp.json()["dates"] == ["2026-04-21", "2026-04-22", "2026-04-23"]
+
+
+def test_edinet_document_list_manifest_502(client):
+    err = _make_http_error("https://r2.example.com/edinet/document-list/manifest.json", 500)
+    with patch("app.routers.edinet.cache.get_manifest", new=AsyncMock(side_effect=err)):
+        resp = client.get("/edinet/document-list/manifest")
+    assert resp.status_code == 502
+
+
 def test_edinet_document_list_by_date_invalid_format(client):
     resp = client.get("/edinet/document-list/20260423")
     assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- `GET /edinet/document-list/manifest` を追加（R2 の `manifest.json` をプロキシ）
- レスポンス: `{"dates": ["2026-04-01", ...]}` — `total_count > 0` の日付一覧（昇順）
- `/manifest` を `/{date}` より前に定義しルート先取りを防止
- キャッシュ TTL: 6時間（`cache.get_manifest` 使用）

既存の `/{date}` エンドポイントはすでに対応済みのため変更なし。

## Test plan
- [ ] `pytest` 全 49 件パス確認済み
- [ ] mini-tools 側で `/manifest` → 日付リスト取得 → `/document-list/{date}` の流れを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)