### PR TITLE
feat: add /econ-calendar/weekly/manifest and /weekly/{week_start} endpoints

### DIFF
--- a/app/routers/econ_calendar.py
+++ b/app/routers/econ_calendar.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -9,6 +11,8 @@ router = APIRouter(prefix="/econ-calendar", tags=["econ-calendar"])
 
 _LATEST_KEY = "econ-calendar/weekly/latest.json"
 _META_KEY = "econ-calendar/weekly/latest_meta.json"
+_MANIFEST_KEY = "econ-calendar/weekly/manifest.json"
+_WEEK_START_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$")
 
 
 class EconEvent(BaseModel):
@@ -80,6 +84,12 @@ class EconWeeklyMeta(BaseModel):
     diff: DiffResult | None = None
 
 
+class EconWeeklyManifest(BaseModel):
+    weeks: list[str]
+    latest: str
+    generated_at: str
+
+
 @router.get(
     "/weekly",
     response_model=EconWeeklyLatest,
@@ -119,4 +129,58 @@ async def get_weekly_meta() -> dict:
             lambda: r2.fetch_json(_META_KEY),
         )
     except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/weekly/manifest",
+    response_model=EconWeeklyManifest,
+    summary="利用可能な週一覧を取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_weekly_manifest() -> dict:
+    """過去週を含む利用可能な週一覧（manifest.json）を返す。
+
+    - `weeks`: 利用可能な week_start 日付の配列（YYYY-MM-DD、降順）
+    - `latest`: 最新の week_start
+    - `generated_at`: manifest 生成日時（UTC ISO 8601）
+
+    キャッシュ TTL: 6時間（可変）。
+    """
+    try:
+        return await cache.get_manifest(
+            "econ-calendar/weekly/manifest",
+            lambda: r2.fetch_json(_MANIFEST_KEY),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/weekly/{week_start}",
+    response_model=EconWeeklyLatest,
+    summary="指定週の経済指標カレンダーを取得",
+    responses={
+        404: {"description": "指定週のデータが R2 に存在しない"},
+        422: {"description": "week_start が YYYY-MM-DD 形式でない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_weekly_by_week(week_start: str) -> dict:
+    """YYYY-MM-DD 形式の週開始日に対応する経済指標カレンダーを返す。
+
+    404 の場合: 指定週のデータが存在しない（未取得週など）。
+    422 の場合: week_start が YYYY-MM-DD 形式でない。キャッシュ TTL: 24時間（不変）。
+    """
+    if not _WEEK_START_RE.match(week_start):
+        raise HTTPException(status_code=422, detail="week_start must be YYYY-MM-DD format")
+    try:
+        return await cache.get_day(
+            f"econ-calendar/weekly/{week_start}",
+            lambda: r2.fetch_json(f"econ-calendar/weekly/{week_start}.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail=f"week not found: {week_start}") from exc
         raise HTTPException(status_code=502, detail=str(exc)) from exc


### PR DESCRIPTION
## Summary

- `GET /econ-calendar/weekly/manifest` — 利用可能な週一覧を返す（6h TTL）
- `GET /econ-calendar/weekly/{week_start}` — 指定週の経済指標カレンダーを返す（24h TTL、404対応）
- `EconWeeklyManifest` モデルを追加（`weeks`, `latest`, `generated_at`）

## 実装詳細

- `/weekly/manifest` を `/{week_start}` より先に定義（FastAPI ルーティング順序の問題を回避）
- `week_start` は `YYYY-MM-DD` 形式で正規表現検証（422 を返す）
- 存在しない週は 404、R2 障害は 502（edinet.py と同じパターン）
- 過去週は不変データのため `cache.get_day()` (24h TTL)、manifest は可変のため `cache.get_manifest()` (6h TTL)

## Test plan

- [ ] `/econ-calendar/weekly/manifest` が manifest.json を返すことを確認
- [ ] `/econ-calendar/weekly/2026-04-28` が当週のJSONを返すことを確認
- [ ] 存在しない週で 404 が返ることを確認
- [ ] 不正な形式で 422 が返ることを確認（例: `/weekly/20260428`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)