### PR TITLE
Add TDNET disclosures API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /market-rankings/dividend-yield/monthly/{year_month}` | 指定月の配当利回りランキング |
 | `GET /edinet/document-list/latest` | EDINET 書類一覧（最新） |
 | `GET /edinet/document-list/{date}` | 指定日の EDINET 書類一覧 |
+| `GET /tdnet/disclosures/latest` | TDNET 全適時開示一覧（最新） |
+| `GET /tdnet/disclosures/{date}` | 指定日の TDNET 全適時開示一覧 |
 | `GET /econ-calendar/weekly` | 今週の経済指標カレンダー |
 | `GET /econ-calendar/weekly/meta` | 経済指標カレンダー更新メタ情報 |
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, econ_calendar, edinet, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, topix33, us_ranking, yutai
+from app.routers import earnings_calendar, econ_calendar, edinet, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, tdnet, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -41,7 +41,9 @@ app = FastAPI(
         "| `/yutai/monthly/{year_month}` | 月次 | 不変（24時間） |\n"
         "| `/market-calendar/*` | 不定期（年次更新時） | 可変（6時間） |\n"
         "| `/edinet/document-list/latest` | 平日 1日1回 | 可変（6時間） |\n"
-        "| `/edinet/document-list/{date}` | 1日1回 | 不変（24時間） |\n\n"
+        "| `/edinet/document-list/{date}` | 1日1回 | 不変（24時間） |\n"
+        "| `/tdnet/disclosures/latest` | 平日 1日1回 | 可変（6時間） |\n"
+        "| `/tdnet/disclosures/{date}` | 1日1回 | 不変（24時間） |\n\n"
         "> **ポーリングはデータの更新頻度に基づいて決定すること**（キャッシュ TTL ではなく）。"
         "全データは最短でも 1日1回の更新のため、ポーリング自体が不要なケースがほとんど。"
     ),
@@ -61,3 +63,4 @@ app.include_router(market_rankings.router)
 app.include_router(us_ranking.router)
 app.include_router(edinet.router)
 app.include_router(econ_calendar.router)
+app.include_router(tdnet.router)

--- a/app/routers/tdnet.py
+++ b/app/routers/tdnet.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/tdnet", tags=["tdnet"])
+
+_PREFIX = "tdnet/disclosures"
+_DATE_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$")
+
+
+class TdnetDisclosureItem(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    disclosure_date: str
+    disclosure_time: str
+    security_code: str
+    company_name: str
+    title: str
+    disclosure_category: str
+    pdf_url: str
+    xbrl_url: str
+    html_url: str
+    has_pdf: bool
+    has_xbrl: bool
+    has_html: bool
+    is_financial_related: bool
+    is_earnings_release: bool
+    is_correction: bool
+    fetched_at: str
+
+
+class TdnetDisclosures(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    target_date: str
+    source: str
+    total_count: int
+    items: list[TdnetDisclosureItem]
+
+
+@router.get(
+    "/disclosures/latest",
+    response_model=TdnetDisclosures,
+    summary="TDNET 全適時開示一覧（最新）を取得",
+    responses={
+        404: {"description": "R2 にファイルが存在しない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_disclosures_latest() -> dict:
+    """最新日の TDNET 全適時開示一覧を返す。
+
+    - `target_date`: データの対象日（YYYY-MM-DD）
+    - `items`: 適時開示エントリの配列
+
+    この API は PDF を再配信せず、market_info が抽出した TDNET 原文 URL を返す。
+    更新単位: 平日 1日1回（TDNET 取得バッチ後）。キャッシュ TTL: 6時間（可変）。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/latest",
+            lambda: r2.fetch_json(f"{_PREFIX}/latest.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail="tdnet disclosures latest not found") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/disclosures/{date}",
+    response_model=TdnetDisclosures,
+    summary="指定日の TDNET 全適時開示一覧を取得",
+    responses={
+        404: {"description": "指定日のデータが R2 に存在しない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_disclosures_by_date(date: str) -> dict:
+    """YYYY-MM-DD 形式の日付に対応する TDNET 全適時開示一覧を返す。
+
+    404 の場合: 指定日のデータが存在しない（未取得日・未来日・publish 未実行日など）。
+    422 の場合: date が YYYY-MM-DD 形式でない。キャッシュ TTL: 24時間（不変）。
+    """
+    if not _DATE_RE.match(date):
+        raise HTTPException(status_code=422, detail="date must be YYYY-MM-DD format")
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{date}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{date}.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail=f"tdnet disclosures not found: {date}") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -62,6 +62,7 @@ API が正常時はローカル JSON を使わないこと（stale データ混�
 | `/earnings-calendar/domestic/*` | 不定期 | 決算データ更新時 |
 | `/earnings-calendar/overseas/*` | 不定期 | 決算データ更新時 |
 | `/edinet/document-list/*` | 平日 1日1回 | 週末・祝日は件数 0 の場合あり |
+| `/tdnet/disclosures/*` | 平日 1日1回 | TDNET 全適時開示一覧。PDF は再配信せず原文 URL を返す |
 | `/sbi/credit/*` | 週次 | SBI 信用残高更新に合わせて publish |
 | `/nikko/credit` | 不定期 | 銘柄追加・除外時 |
 | `/yutai/*` | 月次 | 月初に publish |

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -341,6 +341,42 @@ GET /edinet/document-list/{date}    # date: YYYY-MM-DD
 → （same shape as /edinet/document-list/latest）
 ```
 
+### TDNET 全適時開示一覧
+
+```
+GET /tdnet/disclosures/latest
+→ {
+    "target_date": "2026-05-09",
+    "source": "tdnet_timely_disclosure_list",
+    "total_count": 2,
+    "items": [
+      {
+        "disclosure_date": "2026-05-09",
+        "disclosure_time": "15:00",
+        "security_code": "12340",
+        "company_name": "サンプル株式会社",
+        "title": "2026年3月期 決算短信〔日本基準〕（連結）",
+        "disclosure_category": "決算短信",
+        "pdf_url": "https://www.release.tdnet.info/inbs/140120260509555001.pdf",
+        "xbrl_url": "https://www.release.tdnet.info/inbs/xbrl/140120260509555001.zip",
+        "html_url": "",
+        "has_pdf": true,
+        "has_xbrl": true,
+        "has_html": false,
+        "is_financial_related": true,
+        "is_earnings_release": true,
+        "is_correction": false,
+        "fetched_at": "2026-05-09T12:00:00+09:00"
+      }
+    ]
+  }
+
+GET /tdnet/disclosures/{date}    # date: YYYY-MM-DD
+→ （same shape as /tdnet/disclosures/latest）
+```
+
+PDF / HTML / XBRL は再ホストせず、TDNET 原文 URL を返す。
+
 ### JPX休場日
 
 ```
@@ -408,6 +444,7 @@ curl https://market-info-api-619599800912.asia-northeast1.run.app/earnings-calen
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-rankings/market-cap/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-rankings/dividend-yield/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/edinet/document-list/latest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/tdnet/disclosures/latest
 ```
 
 `/market-calendar/jpx-closed` は `market_closed/jpx_market_closed_latest.json` を固定参照する。

--- a/tests/fixtures/tdnet_disclosures_real_shape.json
+++ b/tests/fixtures/tdnet_disclosures_real_shape.json
@@ -1,0 +1,43 @@
+{
+  "target_date": "2026-05-09",
+  "source": "tdnet_timely_disclosure_list",
+  "total_count": 2,
+  "items": [
+    {
+      "disclosure_date": "2026-05-09",
+      "disclosure_time": "15:00",
+      "security_code": "12340",
+      "company_name": "サンプル株式会社",
+      "title": "2026年3月期 決算短信〔日本基準〕（連結）",
+      "disclosure_category": "決算短信",
+      "pdf_url": "https://www.release.tdnet.info/inbs/140120260509555001.pdf",
+      "xbrl_url": "https://www.release.tdnet.info/inbs/xbrl/140120260509555001.zip",
+      "html_url": "",
+      "has_pdf": true,
+      "has_xbrl": true,
+      "has_html": false,
+      "is_financial_related": true,
+      "is_earnings_release": true,
+      "is_correction": false,
+      "fetched_at": "2026-05-09T12:00:00+09:00"
+    },
+    {
+      "disclosure_date": "2026-05-09",
+      "disclosure_time": "15:10",
+      "security_code": "56780",
+      "company_name": "訂正テスト株式会社",
+      "title": "（訂正・数値データ訂正）2026年3月期 決算短信〔IFRS〕（連結）",
+      "disclosure_category": "決算短信",
+      "pdf_url": "https://www.release.tdnet.info/inbs/140120260509555002.pdf",
+      "xbrl_url": "",
+      "html_url": "https://www.release.tdnet.info/inbs/140120260509555002.html",
+      "has_pdf": true,
+      "has_xbrl": false,
+      "has_html": true,
+      "is_financial_related": true,
+      "is_earnings_release": true,
+      "is_correction": true,
+      "fetched_at": "2026-05-09T12:00:00+09:00"
+    }
+  ]
+}

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -23,6 +23,7 @@ def client(monkeypatch):
     import app.routers.market_calendar as market_calendar_mod
     import app.routers.sbi as sbi_mod
     import app.routers.topix33 as topix33_mod
+    import app.routers.tdnet as tdnet_mod
     import app.routers.yutai as yutai_mod
     import app.routers.market_rankings as market_rankings_mod
     importlib.reload(earnings_calendar_mod)
@@ -31,6 +32,7 @@ def client(monkeypatch):
     importlib.reload(market_calendar_mod)
     importlib.reload(sbi_mod)
     importlib.reload(topix33_mod)
+    importlib.reload(tdnet_mod)
     importlib.reload(yutai_mod)
     importlib.reload(market_rankings_mod)
     from app.main import app
@@ -651,3 +653,49 @@ def test_edinet_document_list_by_date_invalid_format(client):
     resp = client.get("/edinet/document-list/20260423")
     assert resp.status_code == 422
     assert "YYYY-MM-DD" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# tdnet
+# ---------------------------------------------------------------------------
+
+
+def test_tdnet_disclosures_latest_accepts_market_info_shape(client):
+    payload = _load_fixture("tdnet_disclosures_real_shape.json")
+    with patch("app.routers.tdnet.cache.get_manifest", new=AsyncMock(return_value=payload)):
+        resp = client.get("/tdnet/disclosures/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["target_date"] == "2026-05-09"
+    assert data["total_count"] == 2
+    assert data["items"][0]["pdf_url"].endswith(".pdf")
+    assert data["items"][1]["is_correction"] is True
+
+
+def test_tdnet_disclosures_by_date(client):
+    payload = _load_fixture("tdnet_disclosures_real_shape.json")
+    with patch("app.routers.tdnet.cache.get_day", new=AsyncMock(return_value=payload)):
+        resp = client.get("/tdnet/disclosures/2026-05-09")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["security_code"] == "12340"
+
+
+def test_tdnet_disclosures_by_date_not_found(client):
+    err = _make_http_error("https://r2.example.com/tdnet/disclosures/2026-01-01.json", 404)
+    with patch("app.routers.tdnet.cache.get_day", new=AsyncMock(side_effect=err)):
+        resp = client.get("/tdnet/disclosures/2026-01-01")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "tdnet disclosures not found: 2026-01-01"
+
+
+def test_tdnet_disclosures_by_date_invalid_format(client):
+    resp = client.get("/tdnet/disclosures/20260509")
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "date must be YYYY-MM-DD format"
+
+
+def test_tdnet_disclosures_latest_502(client):
+    err = _make_http_error("https://r2.example.com/tdnet/disclosures/latest.json", 500)
+    with patch("app.routers.tdnet.cache.get_manifest", new=AsyncMock(side_effect=err)):
+        resp = client.get("/tdnet/disclosures/latest")
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary
- Add TDNET disclosures router for `GET /tdnet/disclosures/latest` and `GET /tdnet/disclosures/{date}`
- Add response models, docs, and a real-shape fixture-backed regression test
- Validate malformed TDNET date params with 422 before fetching R2

## Verification
- `.\.venv\Scripts\python.exe -m pytest -q` -> 56 passed
- `.\.venv\Scripts\python.exe -m ruff check .` -> passed
- `codex review --uncommitted` found one date validation issue; fixed with a regression test

## Notes
- Backing objects are expected at `tdnet/disclosures/latest.json` and `tdnet/disclosures/YYYY-MM-DD.json`.
