### PR TITLE
Add cached range and ranking search endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /health` | ヘルスチェック |
 | `GET /ranking/manifest` | 株価ランキング manifest |
 | `GET /ranking/{date}` | 指定日のランキング JSON |
+| `GET /ranking/range?from={date}&to={date}` | 期間内のランキング JSON |
+| `GET /ranking/search?from={date}&to={date}` | 期間内のランキング検索 |
 | `GET /topix33/manifest` | TOPIX33 manifest |
 | `GET /topix33/{date}` | 指定日の TOPIX33 JSON |
+| `GET /topix33/range?from={date}&to={date}` | 期間内の TOPIX33 JSON |
 | `GET /nikkei/manifest` | 日経寄与度 manifest |
 | `GET /nikkei/{date}` | 指定日の日経寄与度 JSON |
+| `GET /nikkei/range?from={date}&to={date}` | 期間内の日経寄与度 JSON |
 | `GET /market-calendar/jpx-closed` | JPX 休場日カレンダー |
 | `GET /market-calendar/us-closed` | US 休場日カレンダー |
 | `GET /earnings-calendar/domestic/latest` | 国内決算カレンダー（全件） |
@@ -84,6 +88,7 @@ MARKET_INFO_API_KEY=
 curl http://localhost:8000/health
 curl http://localhost:8000/ranking/manifest
 curl http://localhost:8000/ranking/2026-04-04
+curl "http://localhost:8000/ranking/range?from=2026-04-01&to=2026-04-30"
 curl http://localhost:8000/market-calendar/jpx-closed
 curl http://localhost:8000/market-calendar/us-closed
 ```

--- a/app/cache.py
+++ b/app/cache.py
@@ -11,6 +11,10 @@ _DAY_TTL = 86400        # 24時間（不変データ）
 
 _manifest_cache: TTLCache = TTLCache(maxsize=16, ttl=_MANIFEST_TTL)
 _day_cache: TTLCache = TTLCache(maxsize=128, ttl=_DAY_TTL)
+_range_current_cache: TTLCache = TTLCache(maxsize=64, ttl=_MANIFEST_TTL)
+_range_past_cache: TTLCache = TTLCache(maxsize=64, ttl=_DAY_TTL)
+_search_index_current_cache: TTLCache = TTLCache(maxsize=128, ttl=_MANIFEST_TTL)
+_search_index_past_cache: TTLCache = TTLCache(maxsize=128, ttl=_DAY_TTL)
 
 _locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
@@ -40,3 +44,23 @@ async def get_manifest(key: str, fetch_fn: Callable[[], Awaitable[Any]]) -> Any:
 
 async def get_day(key: str, fetch_fn: Callable[[], Awaitable[Any]]) -> Any:
     return await get_or_fetch(_day_cache, key, fetch_fn)
+
+
+async def get_range(
+    key: str,
+    *,
+    contains_latest: bool,
+    fetch_fn: Callable[[], Awaitable[Any]],
+) -> Any:
+    cache = _range_current_cache if contains_latest else _range_past_cache
+    return await get_or_fetch(cache, key, fetch_fn)
+
+
+async def get_search_index(
+    key: str,
+    *,
+    contains_latest: bool,
+    fetch_fn: Callable[[], Awaitable[Any]],
+) -> Any:
+    cache = _search_index_current_cache if contains_latest else _search_index_past_cache
+    return await get_or_fetch(cache, key, fetch_fn)

--- a/app/range_service.py
+++ b/app/range_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import date
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app import cache
+
+_SCHEMA_VERSION = "range-v1"
+_FETCH_CONCURRENCY = 8
+_MAX_RANGE_SOURCE_DATES = 31
+
+
+class RangeRequestTooLarge(ValueError):
+    pass
+
+
+class RangeEnvelope(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    family: str
+    from_date: date = Field(alias="from")
+    to_date: date = Field(alias="to")
+    bucket: str
+    schema_version: str
+    manifest_version: str
+    source_dates: list[str]
+    missing: list[str]
+    contains_latest: bool
+    items: list[Any]
+
+
+def latest_from_manifest(manifest: dict[str, Any]) -> str | None:
+    for key in ("latest", "latest_date", "latest_month"):
+        value = manifest.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def manifest_version(manifest: dict[str, Any]) -> str:
+    for key in ("generated_at", "latest", "latest_date", "latest_month"):
+        value = manifest.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown"
+
+
+def select_dates(manifest: dict[str, Any], from_date: date, to_date: date) -> list[str]:
+    dates = manifest.get("dates")
+    if not isinstance(dates, list):
+        return []
+
+    selected: list[str] = []
+    for value in dates:
+        if not isinstance(value, str):
+            continue
+        try:
+            parsed = date.fromisoformat(value)
+        except ValueError:
+            continue
+        if from_date <= parsed <= to_date:
+            selected.append(value)
+    return selected
+
+
+def contains_latest_date(manifest: dict[str, Any], source_dates: list[str]) -> bool:
+    latest = latest_from_manifest(manifest)
+    return latest in source_dates if latest else False
+
+
+async def build_daily_range(
+    *,
+    family: str,
+    from_date: date,
+    to_date: date,
+    manifest: dict[str, Any],
+    fetch_day: Callable[[str, str], Awaitable[dict[str, Any]]],
+    bucket: str = "day",
+) -> dict[str, Any]:
+    source_dates = select_dates(manifest, from_date, to_date)
+    if len(source_dates) > _MAX_RANGE_SOURCE_DATES:
+        raise RangeRequestTooLarge(
+            f"range source_dates must be {_MAX_RANGE_SOURCE_DATES} or fewer; got {len(source_dates)}"
+        )
+    contains_latest = contains_latest_date(manifest, source_dates)
+    version = manifest_version(manifest)
+    cache_key = (
+        f"range:{family}:{from_date.isoformat()}:{to_date.isoformat()}:"
+        f"{bucket}:full:{_SCHEMA_VERSION}:{version}"
+    )
+
+    async def fetch_range() -> dict[str, Any]:
+        semaphore = asyncio.Semaphore(_FETCH_CONCURRENCY)
+
+        async def fetch_one(source_date: str) -> tuple[str, dict[str, Any]]:
+            async with semaphore:
+                return source_date, await fetch_day(source_date, version)
+
+        results = await asyncio.gather(*(fetch_one(source_date) for source_date in source_dates))
+        items: list[dict[str, Any]] = []
+        missing: list[str] = []
+        for _source_date, payload in results:
+            items.append(payload)
+
+        return {
+            "family": family,
+            "from_date": from_date,
+            "to_date": to_date,
+            "bucket": bucket,
+            "schema_version": _SCHEMA_VERSION,
+            "manifest_version": version,
+            "source_dates": source_dates,
+            "missing": missing,
+            "contains_latest": contains_latest,
+            "items": items,
+        }
+
+    return await cache.get_range(
+        cache_key,
+        contains_latest=contains_latest,
+        fetch_fn=fetch_range,
+    )

--- a/app/routers/nikkei.py
+++ b/app/routers/nikkei.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from datetime import date
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 
 from app import cache, r2
+from app.range_service import RangeEnvelope, RangeRequestTooLarge, build_daily_range
 
 router = APIRouter(prefix="/nikkei", tags=["nikkei"])
 
@@ -53,6 +57,17 @@ class NikkeiDay(BaseModel):
     records: list[NikkeiRecord]
 
 
+async def _get_day_payload(date_str: str, *, manifest_version_key: str | None = None) -> dict:
+    file_name = f"nikkei_contribution_{date_str}.json"
+    cache_key = f"{_PREFIX}/{date_str}"
+    if manifest_version_key:
+        cache_key = f"{cache_key}:{manifest_version_key}"
+    return await cache.get_day(
+        cache_key,
+        lambda: r2.fetch_json(f"{_PREFIX}/{file_name}"),
+    )
+
+
 @router.get(
     "/manifest",
     response_model=NikkeiManifest,
@@ -77,6 +92,42 @@ async def get_manifest() -> dict:
 
 
 @router.get(
+    "/range",
+    response_model=RangeEnvelope,
+    summary="期間内の日経寄与度 JSON をまとめて取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_range(
+    from_date: date = Query(alias="from", description="開始日（YYYY-MM-DD）"),
+    to_date: date = Query(alias="to", description="終了日（YYYY-MM-DD）"),
+    bucket: Literal["day"] = Query(default="day", description="Phase 1 は day のみ対応"),
+) -> dict:
+    """manifest の `dates` から期間内の日経寄与度 JSON を束ねて返す。
+
+    range response は API 側でキャッシュされる。latest を含む range は 6時間、過去日付のみの range は 24時間。
+    """
+    if from_date > to_date:
+        raise HTTPException(status_code=400, detail="from must be before or equal to to")
+    manifest = await get_manifest()
+    try:
+        return await build_daily_range(
+            family="nikkei",
+            from_date=from_date,
+            to_date=to_date,
+            manifest=manifest,
+            fetch_day=lambda source_date, version: _get_day_payload(
+                source_date,
+                manifest_version_key=version,
+            ),
+            bucket=bucket,
+        )
+    except RangeRequestTooLarge as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
     "/{date}",
     response_model=NikkeiDay,
     summary="指定日の日経寄与度 JSON を取得",
@@ -93,12 +144,8 @@ async def get_day(date: str) -> dict:
 
     404 の場合: 休場日・未来日・バッチ未実行日のいずれか。キャッシュ TTL: 24時間（不変）。
     """
-    file_name = f"nikkei_contribution_{date}.json"
     try:
-        return await cache.get_day(
-            f"{_PREFIX}/{date}",
-            lambda: r2.fetch_json(f"{_PREFIX}/{file_name}"),
-        )
+        return await _get_day_payload(date)
     except Exception as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
         if status == 404:

--- a/app/routers/ranking.py
+++ b/app/routers/ranking.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, ConfigDict
+import re
+from datetime import date, timedelta
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
 
 from app import cache, r2
+from app.range_service import (
+    RangeEnvelope,
+    RangeRequestTooLarge,
+    build_daily_range,
+    contains_latest_date,
+    manifest_version,
+    select_dates,
+)
 
 router = APIRouter(prefix="/ranking", tags=["ranking"])
 
@@ -34,6 +46,129 @@ class RankingDay(BaseModel):
     records: list[RankingRecord]
 
 
+class RankingSearchItem(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    date: str
+    market: str | None = None
+    ranking: str | None = None
+    rank: int | None = None
+    name: str | None = None
+    code: str | None = None
+    price: float | None = None
+    change: float | None = None
+    changeRate: float | None = None
+
+
+class RankingSearchQuery(BaseModel):
+    q: str | None = None
+    code: str | None = None
+    market: str | None = None
+    ranking: str | None = None
+
+
+class RankingSearchEnvelope(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    family: str
+    from_date: date = Field(alias="from")
+    to_date: date = Field(alias="to")
+    schema_version: str
+    manifest_version: str
+    source_dates: list[str]
+    missing: list[str]
+    contains_latest: bool
+    query: RankingSearchQuery
+    items: list[RankingSearchItem]
+
+
+_SEARCH_SCHEMA_VERSION = "search-v1"
+_PERIOD_RE = re.compile(r"^(?P<days>[1-9]\d*)d$")
+_MAX_SEARCH_PERIOD_DAYS = 366
+
+
+def _file_key(date_str: str) -> str:
+    return date_str.replace("-", "")
+
+
+async def _get_day_payload(date_str: str, *, manifest_version_key: str | None = None) -> dict:
+    file_key = _file_key(date_str)
+    cache_key = f"{_PREFIX}/{file_key}"
+    if manifest_version_key:
+        cache_key = f"{cache_key}:{manifest_version_key}"
+    return await cache.get_day(
+        cache_key,
+        lambda: r2.fetch_json(f"{_PREFIX}/{file_key}.json"),
+    )
+
+
+def _resolve_search_dates(
+    *,
+    manifest: dict,
+    from_date: date | None,
+    to_date: date | None,
+    period: str | None,
+) -> tuple[date, date]:
+    if period:
+        if from_date or to_date:
+            raise HTTPException(status_code=400, detail="period cannot be combined with from/to")
+        match = _PERIOD_RE.fullmatch(period.strip())
+        if not match:
+            raise HTTPException(status_code=400, detail="period must be like 30d or 90d")
+        latest = manifest.get("latest")
+        if not isinstance(latest, str) or not latest:
+            raise HTTPException(status_code=502, detail="ranking manifest latest is missing")
+        resolved_to = date.fromisoformat(latest)
+        days = int(match.group("days"))
+        if days > _MAX_SEARCH_PERIOD_DAYS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"period must be {_MAX_SEARCH_PERIOD_DAYS}d or less",
+            )
+        return resolved_to - timedelta(days=days - 1), resolved_to
+
+    if from_date is None or to_date is None:
+        raise HTTPException(status_code=400, detail="from/to or period is required")
+    return from_date, to_date
+
+
+def _compact_record(source_date: str, record: dict) -> dict:
+    return {
+        "date": source_date,
+        "market": record.get("market"),
+        "ranking": record.get("ranking"),
+        "rank": record.get("rank"),
+        "name": record.get("name"),
+        "code": record.get("code"),
+        "price": record.get("price"),
+        "change": record.get("change"),
+        "changeRate": record.get("changeRate"),
+    }
+
+
+def _matches_query(
+    item: dict,
+    *,
+    q: str | None,
+    code: str | None,
+    market: str | None,
+    ranking: str | None,
+) -> bool:
+    if code and str(item.get("code") or "").lower() != code.lower():
+        return False
+    if market and str(item.get("market") or "") != market:
+        return False
+    if ranking and str(item.get("ranking") or "") != ranking:
+        return False
+    if q:
+        needle = q.lower()
+        haystack = " ".join(
+            str(item.get(key) or "")
+            for key in ("code", "name", "market", "ranking")
+        ).lower()
+        if needle not in haystack:
+            return False
+    return True
+
+
 @router.get(
     "/manifest",
     response_model=RankingManifest,
@@ -58,6 +193,120 @@ async def get_manifest() -> dict:
 
 
 @router.get(
+    "/range",
+    response_model=RangeEnvelope,
+    summary="期間内のランキング JSON をまとめて取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_range(
+    from_date: date = Query(alias="from", description="開始日（YYYY-MM-DD）"),
+    to_date: date = Query(alias="to", description="終了日（YYYY-MM-DD）"),
+    bucket: Literal["day"] = Query(default="day", description="Phase 1 は day のみ対応"),
+) -> dict:
+    """manifest の `dates` から期間内の日次ランキング JSON を束ねて返す。
+
+    range response は API 側でキャッシュされる。latest を含む range は 6時間、過去日付のみの range は 24時間。
+    """
+    if from_date > to_date:
+        raise HTTPException(status_code=400, detail="from must be before or equal to to")
+    manifest = await get_manifest()
+    try:
+        return await build_daily_range(
+            family="ranking",
+            from_date=from_date,
+            to_date=to_date,
+            manifest=manifest,
+            fetch_day=lambda source_date, version: _get_day_payload(
+                source_date,
+                manifest_version_key=version,
+            ),
+            bucket=bucket,
+        )
+    except RangeRequestTooLarge as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/search",
+    response_model=RankingSearchEnvelope,
+    summary="期間内のランキングを検索",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def search(
+    from_date: date | None = Query(default=None, alias="from", description="開始日（YYYY-MM-DD）"),
+    to_date: date | None = Query(default=None, alias="to", description="終了日（YYYY-MM-DD）"),
+    period: str | None = Query(default=None, description="期間指定（例: 30d, 90d）"),
+    q: str | None = Query(default=None, description="code/name/market/ranking の部分一致"),
+    code: str | None = Query(default=None, description="銘柄コード完全一致"),
+    market: str | None = Query(default=None, description="市場名完全一致"),
+    ranking: str | None = Query(default=None, description="ランキング種別完全一致"),
+) -> dict:
+    """期間内の日次ランキングから compact search index を作り、該当行だけ返す。
+
+    index と元の日次 object cache は manifest_version 付き key で管理する。
+    """
+    manifest = await get_manifest()
+    resolved_from, resolved_to = _resolve_search_dates(
+        manifest=manifest,
+        from_date=from_date,
+        to_date=to_date,
+        period=period,
+    )
+    if resolved_from > resolved_to:
+        raise HTTPException(status_code=400, detail="from must be before or equal to to")
+
+    source_dates = select_dates(manifest, resolved_from, resolved_to)
+    if len(source_dates) > _MAX_SEARCH_PERIOD_DAYS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"search source_dates must be {_MAX_SEARCH_PERIOD_DAYS} or fewer; got {len(source_dates)}",
+        )
+    contains_latest = contains_latest_date(manifest, source_dates)
+    version = manifest_version(manifest)
+    cache_key = (
+        f"search-index:ranking:{resolved_from.isoformat()}:{resolved_to.isoformat()}:"
+        f"{_SEARCH_SCHEMA_VERSION}:{version}"
+    )
+
+    async def build_index() -> dict:
+        items: list[dict] = []
+        for source_date in source_dates:
+            payload = await _get_day_payload(source_date, manifest_version_key=version)
+            for record in payload.get("records", []):
+                if isinstance(record, dict):
+                    items.append(_compact_record(source_date, record))
+        return {"items": items, "missing": []}
+
+    try:
+        index = await cache.get_search_index(
+            cache_key,
+            contains_latest=contains_latest,
+            fetch_fn=build_index,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    items = [
+        item
+        for item in index["items"]
+        if _matches_query(item, q=q, code=code, market=market, ranking=ranking)
+    ]
+    return {
+        "family": "ranking",
+        "from_date": resolved_from,
+        "to_date": resolved_to,
+        "schema_version": _SEARCH_SCHEMA_VERSION,
+        "manifest_version": version,
+        "source_dates": source_dates,
+        "missing": index["missing"],
+        "contains_latest": contains_latest,
+        "query": {"q": q, "code": code, "market": market, "ranking": ranking},
+        "items": items,
+    }
+
+
+@router.get(
     "/{date}",
     response_model=RankingDay,
     summary="指定日のランキング JSON を取得",
@@ -75,12 +324,8 @@ async def get_day(date: str) -> dict:
     404 の場合: 休場日・未来日・バッチ未実行日のいずれか。キャッシュ TTL: 24時間（不変）。
     mini-tools 側は manifest の `dates` に含まれる日付のみリクエストすること。
     """
-    file_key = date.replace("-", "")
     try:
-        return await cache.get_day(
-            f"{_PREFIX}/{file_key}",
-            lambda: r2.fetch_json(f"{_PREFIX}/{file_key}.json"),
-        )
+        return await _get_day_payload(date)
     except Exception as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
         if status == 404:

--- a/app/routers/topix33.py
+++ b/app/routers/topix33.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from datetime import date
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 
 from app import cache, r2
+from app.range_service import RangeEnvelope, RangeRequestTooLarge, build_daily_range
 
 router = APIRouter(prefix="/topix33", tags=["topix33"])
 
@@ -50,6 +54,17 @@ class Topix33Day(BaseModel):
     sectors: list[Topix33Sector]
 
 
+async def _get_day_payload(date_str: str, *, manifest_version_key: str | None = None) -> dict:
+    file_name = f"topix33_{date_str}.json"
+    cache_key = f"{_PREFIX}/{date_str}"
+    if manifest_version_key:
+        cache_key = f"{cache_key}:{manifest_version_key}"
+    return await cache.get_day(
+        cache_key,
+        lambda: r2.fetch_json(f"{_PREFIX}/{file_name}"),
+    )
+
+
 @router.get(
     "/manifest",
     response_model=Topix33Manifest,
@@ -74,6 +89,42 @@ async def get_manifest() -> dict:
 
 
 @router.get(
+    "/range",
+    response_model=RangeEnvelope,
+    summary="期間内の TOPIX33 JSON をまとめて取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_range(
+    from_date: date = Query(alias="from", description="開始日（YYYY-MM-DD）"),
+    to_date: date = Query(alias="to", description="終了日（YYYY-MM-DD）"),
+    bucket: Literal["day"] = Query(default="day", description="Phase 1 は day のみ対応"),
+) -> dict:
+    """manifest の `dates` から期間内の TOPIX33 日次 JSON を束ねて返す。
+
+    range response は API 側でキャッシュされる。latest を含む range は 6時間、過去日付のみの range は 24時間。
+    """
+    if from_date > to_date:
+        raise HTTPException(status_code=400, detail="from must be before or equal to to")
+    manifest = await get_manifest()
+    try:
+        return await build_daily_range(
+            family="topix33",
+            from_date=from_date,
+            to_date=to_date,
+            manifest=manifest,
+            fetch_day=lambda source_date, version: _get_day_payload(
+                source_date,
+                manifest_version_key=version,
+            ),
+            bucket=bucket,
+        )
+    except RangeRequestTooLarge as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
     "/{date}",
     response_model=Topix33Day,
     summary="指定日の TOPIX33 JSON を取得",
@@ -90,12 +141,8 @@ async def get_day(date: str) -> dict:
 
     404 の場合: 休場日・未来日・バッチ未実行日のいずれか。キャッシュ TTL: 24時間（不変）。
     """
-    file_name = f"topix33_{date}.json"
     try:
-        return await cache.get_day(
-            f"{_PREFIX}/{date}",
-            lambda: r2.fetch_json(f"{_PREFIX}/{file_name}"),
-        )
+        return await _get_day_payload(date)
     except Exception as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
         if status == 404:

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -53,10 +53,10 @@ API が正常時はローカル JSON を使わないこと（stale データ混�
 |------------------------|----------------|------|
 | `/econ-calendar/weekly` | 平日 1日1回（01:00 UTC） | 実績値マージ後に publish。**ポーリング不要** |
 | `/econ-calendar/weekly/meta` | 平日 1日1回（01:00 UTC） | 同上 |
-| `/ranking/*` | 営業日ごと | market_info の日次バッチ完了後 |
-| `/us-ranking/*` | 営業日ごと | 同上 |
-| `/topix33/*` | 営業日ごと | 同上 |
-| `/nikkei/*` | 営業日ごと | 同上 |
+| `/ranking/*` | publish 時（通常は営業日ごと想定） | market_info の日次バッチ完了後。API は manifest の実内容を正とする |
+| `/us-ranking/*` | publish 時（通常は営業日ごと想定） | 同上 |
+| `/topix33/*` | publish 時（通常は営業日ごと想定） | 同上 |
+| `/nikkei/*` | publish 時（通常は営業日ごと想定） | 同上 |
 | `/market-calendar/jpx-closed` | 不定期（年次更新） | 休場日カレンダー更新時 |
 | `/market-calendar/us-closed` | 不定期（年次更新） | 休場日カレンダー更新時 |
 | `/earnings-calendar/domestic/*` | 不定期 | 決算データ更新時 |
@@ -87,6 +87,96 @@ manifest に含まれない日付・月をリクエストした場合、404 が�
 ```
 
 ※ topix33 / nikkei は `latest_date` キーを使う（`latest` ではない）。
+
+### ranking / topix33 / nikkei の range response
+
+`/ranking/range`, `/topix33/range`, `/nikkei/range` は manifest の `dates` から `from` / `to` に含まれる source date を選び、既存の日次 payload を `items[]` に束ねて返す。
+Phase 1 は `bucket=day` のみ対応する。
+Full payload を返すため、Phase 1 の range は最大 31 source dates までとし、超過時は 400 を返す。
+Windows Task Scheduler の予定時刻ではなく、R2 の manifest に含まれる dates/latest metadata を正として range を解決する。
+
+```json
+{
+  "family": "ranking",
+  "from": "2026-04-01",
+  "to": "2026-04-30",
+  "bucket": "day",
+  "schema_version": "range-v1",
+  "manifest_version": "2026-05-19T16:10:00Z",
+  "source_dates": ["2026-04-30", "2026-04-28"],
+  "missing": [],
+  "contains_latest": true,
+  "items": []
+}
+```
+
+`missing[]` は将来の部分取得許容用フィールドとして維持する。
+Phase 1 では、manifest に含まれる source date の取得に失敗した場合、不完全な response を cache しないため request 全体を 502 にする。
+休場日など manifest に含まれない日付は `source_dates` に入らず、`missing[]` にも入れない。
+
+range response と、その元になる日次 object cache は `manifest_version` を cache key に含める。
+これにより、過去日付の object が再publishされ manifest `generated_at` が更新された場合に、古い日次 cache と新しい manifest が混在しないようにする。
+
+### ranking search response
+
+広範囲の UI 検索では、full payload を返す `/ranking/range` ではなく、API 側で compact search index を作って該当結果だけ返す `/ranking/search` を使う。
+
+```text
+GET /ranking/search?from=2026-04-01&to=2026-05-19&q=トヨタ
+GET /ranking/search?from=2026-04-01&to=2026-05-19&code=7203
+GET /ranking/search?period=90d&market=東証プライム&ranking=値上がり率
+```
+
+`period` は `Nd` 形式で、Phase 1 は最大 `366d` とする。
+`from` / `to` を直接指定した場合も、選択される source dates は最大 366 件までとし、超過時は 400 を返す。
+
+Response:
+
+```json
+{
+  "family": "ranking",
+  "from": "2026-04-01",
+  "to": "2026-05-19",
+  "schema_version": "search-v1",
+  "manifest_version": "2026-05-19T16:10:00Z",
+  "source_dates": ["2026-05-19", "2026-05-18"],
+  "missing": [],
+  "contains_latest": true,
+  "query": {
+    "q": "トヨタ",
+    "code": null,
+    "market": null,
+    "ranking": null
+  },
+  "items": [
+    {
+      "date": "2026-05-19",
+      "market": "東証プライム",
+      "ranking": "値上がり率",
+      "rank": 12,
+      "name": "トヨタ自動車",
+      "code": "7203",
+      "price": 1234.0,
+      "change": 12.0,
+      "changeRate": 1.23
+    }
+  ]
+}
+```
+
+Search index は query ごとではなく、期間と `manifest_version` ごとにキャッシュする。
+検索条件は cached index に毎回適用するため、同じ期間に対する複数検索で R2 読み込みを再利用できる。
+
+```text
+search-index:ranking:{from}:{to}:search-v1:{manifest_version}
+```
+
+R2 更新時の扱い:
+
+- manifest の `latest` / `generated_at` が変われば `manifest_version` が変わり、新しい range/search cache と日次 object cache を使う。
+- 過去日付の object を再publishする場合も、manifest の `generated_at` を更新すること。
+- manifest metadata が変わらない object 差し替えは API が検知できず、TTL が切れるまで古い cache を返す可能性がある。
+- source date の一部取得に失敗した search index は cache しない。request 全体を 502 にする。
 
 ### yutai の manifest
 
@@ -245,7 +335,9 @@ TTL はデータの**可変性**によって 2 種類に分ける。TTL はサ�
 
 > この TTL 設計は market_info の publish スケジュールに依存する。**最短更新間隔が 24時間未満に変わった場合は TTL を合わせて見直すこと**。設計ルールの正本は `market_info/docs/reference/policy_decision_rules.md` を参照。
 
-TTL の実装値は `app/cache.py` の `_MANIFEST_TTL`（21600秒）/ `_DAY_TTL`（86400秒）を参照。  
+TTL の実装値は `app/cache.py` の `_MANIFEST_TTL`（21600秒）/ `_DAY_TTL`（86400秒）を参照。
+range response は latest/current period を含む場合 `_MANIFEST_TTL`、過去 immutable source のみの場合 `_DAY_TTL` を使う。
+search index も同じ TTL 方針を使う。
 テスト時は R2 への実リクエストをモックするか、キャッシュをクリアして確認すること。
 
 ### ポーリングについて

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -85,6 +85,35 @@ GET /ranking/manifest
 
 GET /ranking/{date}         # date: YYYY-MM-DD
 → {"date": "2026-03-27", "records": [...]}
+
+GET /ranking/range?from=2026-03-01&to=2026-03-31
+→ {
+    "family": "ranking",
+    "from": "2026-03-01",
+    "to": "2026-03-31",
+    "bucket": "day",
+    "schema_version": "range-v1",
+    "source_dates": ["2026-03-31", ...],
+    "missing": [],
+    "contains_latest": true,
+    "items": [{"date": "2026-03-31", "records": [...]}]
+  }
+
+※ `/ranking/range`, `/nikkei/range`, `/topix33/range` は full payload を束ねるため、Phase 1 は最大 31 source dates まで。広い検索用途は `/ranking/search?period=90d` のような compact search endpoint を使う。
+
+GET /ranking/search?from=2026-03-01&to=2026-03-31&code=7203
+→ {
+    "family": "ranking",
+    "from": "2026-03-01",
+    "to": "2026-03-31",
+    "schema_version": "search-v1",
+    "manifest_version": "...",
+    "source_dates": ["2026-03-31", ...],
+    "missing": [],
+    "contains_latest": true,
+    "query": {"q": null, "code": "7203", "market": null, "ranking": null},
+    "items": [{"date": "2026-03-31", "code": "7203", "name": "..."}]
+  }
 ```
 
 ### 日経寄与度
@@ -95,6 +124,9 @@ GET /nikkei/manifest
 
 GET /nikkei/{date}          # date: YYYY-MM-DD
 → {"date": "2026-03-27", "index": "nikkei225", "records": [...]}
+
+GET /nikkei/range?from=2026-03-01&to=2026-03-31
+→ {"family": "nikkei", "source_dates": [...], "missing": [], "items": [...]}
 ```
 
 ### TOPIX33
@@ -113,6 +145,9 @@ GET /topix33/{date}         # date: YYYY-MM-DD
     "top_negative": [...],
     "sectors": [...]
   }
+
+GET /topix33/range?from=2026-04-01&to=2026-04-30
+→ {"family": "topix33", "source_dates": [...], "missing": [], "items": [...]}
 ```
 
 ### 株主優待
@@ -428,10 +463,14 @@ GET /market-calendar/us-closed
 curl https://market-info-api-619599800912.asia-northeast1.run.app/health
 curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/2026-03-27
+curl "https://market-info-api-619599800912.asia-northeast1.run.app/ranking/range?from=2026-03-01&to=2026-03-31"
+curl "https://market-info-api-619599800912.asia-northeast1.run.app/ranking/search?from=2026-03-01&to=2026-03-31&code=7203"
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/2026-03-27
+curl "https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/range?from=2026-03-01&to=2026-03-31"
 curl https://market-info-api-619599800912.asia-northeast1.run.app/topix33/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/topix33/2026-04-01
+curl "https://market-info-api-619599800912.asia-northeast1.run.app/topix33/range?from=2026-04-01&to=2026-04-30"
 curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/monthly/2026-12
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikko/credit

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 import httpx
+from datetime import date, timedelta
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, patch
 import json
@@ -82,6 +83,167 @@ def test_ranking_day(client):
     assert resp.json()["date"] == "2026-03-28"
 
 
+def test_ranking_range_uses_manifest_dates_and_marks_latest(client):
+    manifest = {"dates": ["2026-05-19", "2026-05-18", "2026-05-16"], "latest": "2026-05-19"}
+
+    async def fetch_day(source_date: str, *, manifest_version_key: str | None = None):
+        assert manifest_version_key == "2026-05-19"
+        return {"date": source_date, "records": []}
+
+    with (
+        patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.ranking._get_day_payload", new=AsyncMock(side_effect=fetch_day)),
+    ):
+        resp = client.get("/ranking/range?from=2026-05-18&to=2026-05-19")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["family"] == "ranking"
+    assert data["from"] == "2026-05-18"
+    assert data["to"] == "2026-05-19"
+    assert data["manifest_version"] == "2026-05-19"
+    assert data["source_dates"] == ["2026-05-19", "2026-05-18"]
+    assert data["missing"] == []
+    assert data["contains_latest"] is True
+    assert data["items"] == [
+        {"date": "2026-05-19", "records": []},
+        {"date": "2026-05-18", "records": []},
+    ]
+
+
+def test_ranking_range_rejects_reversed_dates(client):
+    resp = client.get("/ranking/range?from=2026-05-20&to=2026-05-19")
+    assert resp.status_code == 400
+
+
+def test_ranking_range_fetch_failure_returns_502(client):
+    manifest = {"dates": ["2026-05-19"], "latest": "2026-05-19"}
+
+    with (
+        patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.ranking._get_day_payload", new=AsyncMock(side_effect=RuntimeError("r2 down"))),
+    ):
+        resp = client.get("/ranking/range?from=2026-05-19&to=2026-05-19")
+
+    assert resp.status_code == 502
+
+
+def test_ranking_range_rejects_too_many_source_dates(client):
+    dates = [(date(2026, 5, 1) + timedelta(days=offset)).isoformat() for offset in range(32)]
+    manifest = {"dates": dates, "latest": dates[-1]}
+
+    with patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get(f"/ranking/range?from={dates[0]}&to={dates[-1]}")
+
+    assert resp.status_code == 400
+    assert "source_dates" in resp.json()["detail"]
+
+
+def test_ranking_search_filters_compact_index(client):
+    manifest = {
+        "dates": ["2026-05-19", "2026-05-18"],
+        "latest": "2026-05-19",
+        "generated_at": "2026-05-19T00:00:00Z",
+    }
+
+    async def fetch_day(source_date: str, *, manifest_version_key: str | None = None):
+        assert manifest_version_key == "2026-05-19T00:00:00Z"
+        return {
+            "date": source_date,
+            "records": [
+                {
+                    "market": "東証プライム",
+                    "ranking": "値上がり率",
+                    "rank": 1,
+                    "name": "トヨタ自動車",
+                    "code": "7203",
+                    "price": 1000.0,
+                    "change": 10.0,
+                    "changeRate": 1.0,
+                },
+                {
+                    "market": "東証プライム",
+                    "ranking": "売買高",
+                    "rank": 2,
+                    "name": "別銘柄",
+                    "code": "9999",
+                    "price": 500.0,
+                    "change": -5.0,
+                    "changeRate": -1.0,
+                },
+            ],
+        }
+
+    with (
+        patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.ranking._get_day_payload", new=AsyncMock(side_effect=fetch_day)),
+    ):
+        resp = client.get("/ranking/search?from=2026-05-18&to=2026-05-19&code=7203")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["schema_version"] == "search-v1"
+    assert data["manifest_version"] == "2026-05-19T00:00:00Z"
+    assert data["contains_latest"] is True
+    assert len(data["items"]) == 2
+    assert {item["date"] for item in data["items"]} == {"2026-05-18", "2026-05-19"}
+    assert all(item["code"] == "7203" for item in data["items"])
+
+
+def test_ranking_search_requires_period_or_from_to(client):
+    manifest = {"dates": ["2026-05-19"], "latest": "2026-05-19"}
+    with patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get("/ranking/search?q=7203")
+    assert resp.status_code == 400
+
+
+def test_ranking_search_period_uses_manifest_latest(client):
+    manifest = {"dates": ["2026-05-19", "2026-05-18"], "latest": "2026-05-19"}
+
+    async def fetch_day(source_date: str, *, manifest_version_key: str | None = None):
+        return {"date": source_date, "records": []}
+
+    with (
+        patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.ranking._get_day_payload", new=AsyncMock(side_effect=fetch_day)),
+    ):
+        resp = client.get("/ranking/search?period=2d")
+
+    assert resp.status_code == 200
+    assert resp.json()["from"] == "2026-05-18"
+    assert resp.json()["to"] == "2026-05-19"
+
+
+def test_ranking_search_rejects_oversized_period(client):
+    manifest = {"dates": ["2026-05-19"], "latest": "2026-05-19"}
+    with patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get("/ranking/search?period=1000000d")
+    assert resp.status_code == 400
+
+
+def test_ranking_search_rejects_too_many_source_dates(client):
+    dates = [(date(2025, 1, 1) + timedelta(days=offset)).isoformat() for offset in range(367)]
+    manifest = {"dates": dates, "latest": dates[-1]}
+
+    with patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get(f"/ranking/search?from={dates[0]}&to={dates[-1]}")
+
+    assert resp.status_code == 400
+    assert "source_dates" in resp.json()["detail"]
+
+
+def test_ranking_search_fetch_failure_returns_502(client):
+    manifest = {"dates": ["2026-05-19"], "latest": "2026-05-19"}
+
+    with (
+        patch("app.routers.ranking.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.ranking._get_day_payload", new=AsyncMock(side_effect=RuntimeError("r2 down"))),
+    ):
+        resp = client.get("/ranking/search?from=2026-05-19&to=2026-05-19")
+
+    assert resp.status_code == 502
+
+
 def test_nikkei_manifest(client):
     manifest = {"dates": ["2026-03-28"], "latest_date": "2026-03-28", "generated_at": ""}
     with patch("app.routers.nikkei.cache.get_manifest", new=AsyncMock(return_value=manifest)):
@@ -105,6 +267,32 @@ def test_nikkei_day(client):
         resp = client.get("/nikkei/2026-03-28")
     assert resp.status_code == 200
     assert resp.json()["date"] == "2026-03-28"
+
+
+def test_nikkei_range_uses_latest_date(client):
+    manifest = {"dates": ["2026-05-19", "2026-05-16"], "latest_date": "2026-05-19"}
+
+    async def fetch_day(source_date: str, *, manifest_version_key: str | None = None):
+        return {
+            "date": source_date,
+            "index": "nikkei225",
+            "summary": {"total_contribution": 0.0, "advancers": 0, "decliners": 0, "unchanged": 0},
+            "top_positive": [],
+            "top_negative": [],
+            "records": [],
+        }
+
+    with (
+        patch("app.routers.nikkei.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.nikkei._get_day_payload", new=AsyncMock(side_effect=fetch_day)),
+    ):
+        resp = client.get("/nikkei/range?from=2026-05-16&to=2026-05-18")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["contains_latest"] is False
+    assert data["source_dates"] == ["2026-05-16"]
+    assert data["items"][0]["date"] == "2026-05-16"
 
 
 def test_market_calendar_jpx_closed(client):
@@ -316,6 +504,32 @@ def test_topix33_day(client):
         resp = client.get("/topix33/2026-04-01")
     assert resp.status_code == 200
     assert resp.json()["index"] == "topix33"
+
+
+def test_topix33_range(client):
+    manifest = {"dates": ["2026-04-02", "2026-04-01"], "latest_date": "2026-04-02"}
+
+    async def fetch_day(source_date: str, *, manifest_version_key: str | None = None):
+        return {
+            "date": source_date,
+            "index": "topix33",
+            "summary": {"advancers": 20, "decliners": 12, "unchanged": 1},
+            "top_positive": [],
+            "top_negative": [],
+            "sectors": [],
+        }
+
+    with (
+        patch("app.routers.topix33.get_manifest", new=AsyncMock(return_value=manifest)),
+        patch("app.routers.topix33._get_day_payload", new=AsyncMock(side_effect=fetch_day)),
+    ):
+        resp = client.get("/topix33/range?from=2026-04-01&to=2026-04-02")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["family"] == "topix33"
+    assert data["contains_latest"] is True
+    assert len(data["items"]) == 2
 
 
 def test_yutai_manifest(client):


### PR DESCRIPTION
## Summary

- add cached daily range endpoints for ranking, topix33, and nikkei
- add `/ranking/search` with compact search-index caching keyed by `manifest_version`
- prevent stale/mixed data by using manifest-versioned cache keys for range/search day object reads
- bound full range responses to 31 source dates and ranking search indexes to 366 source dates
- document range/search contracts, R2 update behavior, and failure behavior

## Verification

- `ruff check .`
- `.venv\Scripts\python.exe -m pytest` (68 passed; existing `.pytest_cache` permission warning)
- `codex review --uncommitted` (no discrete correctness issues)
