### PR TITLE
feat: add investor-flow endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /ranking/{date}` | 指定日のランキング JSON |
 | `GET /ranking/range?from={date}&to={date}` | 期間内のランキング JSON |
 | `GET /ranking/search?from={date}&to={date}` | 期間内のランキング検索 |
+| `GET /ranking-enriched/manifest` | enriched 株価ランキング manifest |
+| `GET /ranking-enriched/{date}` | 指定日の enriched ランキング JSON |
 | `GET /topix33/manifest` | TOPIX33 manifest |
 | `GET /topix33/{date}` | 指定日の TOPIX33 JSON |
 | `GET /topix33/range?from={date}&to={date}` | 期間内の TOPIX33 JSON |
@@ -92,6 +94,7 @@ curl http://localhost:8000/health
 curl http://localhost:8000/ranking/manifest
 curl http://localhost:8000/ranking/2026-04-04
 curl "http://localhost:8000/ranking/range?from=2026-04-01&to=2026-04-30"
+curl http://localhost:8000/ranking-enriched/manifest
 curl http://localhost:8000/market-calendar/jpx-closed
 curl http://localhost:8000/market-calendar/us-closed
 curl http://localhost:8000/investor-flow/latest

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /market-rankings/market-cap/monthly/{year_month}` | 指定月の時価総額ランキング |
 | `GET /market-rankings/dividend-yield/manifest` | 配当利回りランキング manifest |
 | `GET /market-rankings/dividend-yield/monthly/{year_month}` | 指定月の配当利回りランキング |
+| `GET /investor-flow/latest` | 投資主体別売買動向（最新） |
+| `GET /investor-flow/manifest` | 投資主体別売買動向 manifest |
+| `GET /investor-flow/weeks/{start_date}/{end_date}` | 指定週の投資主体別売買動向 |
 | `GET /edinet/document-list/latest` | EDINET 書類一覧（最新） |
 | `GET /edinet/document-list/{date}` | 指定日の EDINET 書類一覧 |
 | `GET /tdnet/disclosures/latest` | TDNET 全適時開示一覧（最新） |
@@ -91,6 +94,7 @@ curl http://localhost:8000/ranking/2026-04-04
 curl "http://localhost:8000/ranking/range?from=2026-04-01&to=2026-04-30"
 curl http://localhost:8000/market-calendar/jpx-closed
 curl http://localhost:8000/market-calendar/us-closed
+curl http://localhost:8000/investor-flow/latest
 ```
 
 ---

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, tdnet, topix33, us_ranking, yutai
+from app.routers import earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, ranking_enriched, sbi, tdnet, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -26,6 +26,8 @@ app = FastAPI(
         "| `/earnings-calendar/*/monthly/{year_month}` | 不定期 | 不変（24時間） |\n"
         "| `/ranking/manifest` | 営業日ごと（日次バッチ後） | 可変（6時間） |\n"
         "| `/ranking/{date}` | 営業日ごと | 不変（24時間） |\n"
+        "| `/ranking-enriched/manifest` | 営業日ごと（publish された場合） | 可変（6時間） |\n"
+        "| `/ranking-enriched/{date}` | 営業日ごと（publish された場合） | 不変（24時間） |\n"
         "| `/nikkei/manifest` | 営業日ごと | 可変（6時間） |\n"
         "| `/nikkei/{date}` | 営業日ごと | 不変（24時間） |\n"
         "| `/topix33/manifest` | 営業日ごと | 可変（6時間） |\n"
@@ -56,6 +58,7 @@ app = FastAPI(
 app.include_router(health.router)
 app.include_router(earnings_calendar.router)
 app.include_router(ranking.router)
+app.include_router(ranking_enriched.router)
 app.include_router(nikkei.router)
 app.include_router(sbi.router)
 app.include_router(nikko.router)

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, econ_calendar, edinet, health, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, tdnet, topix33, us_ranking, yutai
+from app.routers import earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, sbi, tdnet, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -34,6 +34,9 @@ app = FastAPI(
         "| `/us-ranking/{date}` | 営業日ごと | 不変（24時間） |\n"
         "| `/market-rankings/*/manifest` | 月次 | 可変（6時間） |\n"
         "| `/market-rankings/*/monthly/{year_month}` | 月次 | 不変（24時間） |\n"
+        "| `/investor-flow/latest` | 週次 | 可変（6時間） |\n"
+        "| `/investor-flow/manifest` | 週次 | 可変（6時間） |\n"
+        "| `/investor-flow/weeks/{start_date}/{end_date}` | 週次 | 不変（24時間） |\n"
         "| `/sbi/credit/latest` | 週次 | 可変（6時間） |\n"
         "| `/sbi/credit/monthly/{year_month}` | 週次 | 不変（24時間） |\n"
         "| `/nikko/credit` | 不定期 | 可変（6時間） |\n"
@@ -64,3 +67,4 @@ app.include_router(us_ranking.router)
 app.include_router(edinet.router)
 app.include_router(econ_calendar.router)
 app.include_router(tdnet.router)
+app.include_router(investor_flow.router)

--- a/app/routers/investor_flow.py
+++ b/app/routers/investor_flow.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/investor-flow", tags=["investor-flow"])
+
+_PREFIX = "investor-flow"
+_DATE_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$")
+
+
+class InvestorFlowWeekRef(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    start_date: str
+    end_date: str
+    path: str
+
+
+class InvestorFlowManifest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    data_source: str
+    latest: InvestorFlowWeekRef
+    weeks: list[InvestorFlowWeekRef]
+    generated_at_jst: str
+
+
+class InvestorFlowRecord(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    row_index: int
+    category: str
+    sell_thousand_yen: int
+    share_sell_pct: float | None
+    buy_thousand_yen: int
+    share_buy_pct: float | None
+    diff_thousand_yen: int
+    sell_yen: int
+    buy_yen: int
+    diff_yen: int
+
+
+class InvestorFlowPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    data_source: str
+    source_url: str
+    source_file: str
+    week_label_raw: str
+    start_date: str
+    end_date: str
+    market_scope: str
+    unit: str
+    generated_at_jst: str
+    records: list[InvestorFlowRecord]
+
+
+@router.get(
+    "/latest",
+    response_model=InvestorFlowPayload,
+    summary="投資主体別売買動向（最新）を取得",
+    responses={
+        404: {"description": "最新データが R2 に存在しない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_latest() -> dict:
+    """最新週の JPX 投資主体別売買動向を返す。
+
+    更新単位: 週次。キャッシュ TTL: 6時間（可変）。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/latest",
+            lambda: r2.fetch_json(f"{_PREFIX}/latest.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail="investor-flow latest not found") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/manifest",
+    response_model=InvestorFlowManifest,
+    summary="投資主体別売買動向 manifest を取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_manifest() -> dict:
+    """利用可能な週次 snapshot の一覧を返す。
+
+    キャッシュ TTL: 6時間（可変）。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/manifest",
+            lambda: r2.fetch_json(f"{_PREFIX}/manifest.json"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/weeks/{start_date}/{end_date}",
+    response_model=InvestorFlowPayload,
+    summary="指定週の投資主体別売買動向を取得",
+    responses={
+        404: {"description": "指定週のデータが R2 に存在しない"},
+        422: {"description": "start_date / end_date が YYYY-MM-DD 形式でない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_week(start_date: str, end_date: str) -> dict:
+    """YYYY-MM-DD の開始日・終了日に対応する週次 snapshot を返す。
+
+    404 の場合: 指定週のデータが存在しない。manifest の `weeks[].path` に含まれる週のみリクエストすること。
+    422 の場合: start_date / end_date が YYYY-MM-DD 形式でない。キャッシュ TTL: 24時間（不変）。
+    """
+    if not _DATE_RE.match(start_date) or not _DATE_RE.match(end_date):
+        raise HTTPException(status_code=422, detail="start_date and end_date must be YYYY-MM-DD format")
+    object_name = f"investor_flow_{start_date}_to_{end_date}.json"
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{start_date}/{end_date}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{object_name}"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=f"investor-flow week not found: {start_date} to {end_date}",
+            ) from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/routers/ranking_enriched.py
+++ b/app/routers/ranking_enriched.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/ranking-enriched", tags=["ranking-enriched"])
+
+_PREFIX = "stock-ranking-enriched"
+
+
+class EnrichedRankingManifest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    dates: list[str]
+    latest: str
+
+
+class EnrichedRankingRecord(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    market: str
+    ranking: str
+    rank: int
+    name: str
+    code: str
+    marketLabel: str
+    industry: str
+    price: float
+    time: str
+    change: float
+    changeRate: float
+    volume: float
+    value: float
+    volumeSpikePct: float | None
+    per: float | None
+    pbr: float | None
+    tickCount: float | None
+    upCount: float | None
+    downCount: float | None
+    marketCapOkuYen: float | None
+    dividendYieldPct: float | None
+
+
+class EnrichedRankingDay(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    date: str
+    records: list[EnrichedRankingRecord]
+
+
+@router.get(
+    "/manifest",
+    response_model=EnrichedRankingManifest,
+    summary="enriched ランキング manifest を取得",
+    responses={502: {"description": "R2 からの取得失敗"}},
+)
+async def get_manifest() -> dict:
+    """stock-ranking-enriched の manifest.json を返す。
+
+    - `latest`: 最新日付（YYYY-MM-DD）
+    - `dates`: 利用可能な日付の降順リスト
+
+    更新単位: 営業日ごと（publish された場合）。キャッシュ TTL: 6時間（可変）。
+    """
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/manifest",
+            lambda: r2.fetch_json(f"{_PREFIX}/manifest.json"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get(
+    "/{date}",
+    response_model=EnrichedRankingDay,
+    summary="指定日の enriched ランキング JSON を取得",
+    responses={
+        404: {"description": "指定日のデータが R2 に存在しない（未 publish 日など）"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_day(date: str) -> dict:
+    """YYYY-MM-DD 形式の日付に対応する enriched ranking JSON を返す。
+
+    404 の場合: 指定日の enriched JSON が存在しない。キャッシュ TTL: 24時間（不変）。
+    """
+    file_key = date.replace("-", "")
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{file_key}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{file_key}.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail=f"ranking-enriched not found: {date}") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -84,6 +84,7 @@ API が正常時はローカル JSON を使わないこと（stale データ混�
 | `/yutai/*` | 月次 | 月初に publish |
 | `/market-rankings/market-cap/*` | 月次 | 月初に publish |
 | `/market-rankings/dividend-yield/*` | 月次 | 月初に publish |
+| `/investor-flow/*` | 週次 | JPX 公式 Excel 掲載後に publish |
 
 ---
 
@@ -244,6 +245,30 @@ R2 更新時の扱い:
 ```
 
 国内・海外とも同じ manifest shape を返す。
+
+### investor-flow の manifest
+
+```json
+{
+  "data_source": "JPX",
+  "latest": {
+    "start_date": "YYYY-MM-DD",
+    "end_date": "YYYY-MM-DD",
+    "path": "investor_flow_YYYY-MM-DD_to_YYYY-MM-DD.json"
+  },
+  "weeks": [
+    {
+      "start_date": "YYYY-MM-DD",
+      "end_date": "YYYY-MM-DD",
+      "path": "investor_flow_YYYY-MM-DD_to_YYYY-MM-DD.json"
+    }
+  ],
+  "generated_at_jst": "YYYY-MM-DDTHH:MM:SS+09:00"
+}
+```
+
+`/investor-flow/weeks/{start_date}/{end_date}` は `investor-flow/investor_flow_{start_date}_to_{end_date}.json` を読む。
+`start_date` / `end_date` は YYYY-MM-DD 形式で、API 側で 422 を返す。
 
 ---
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -70,6 +70,7 @@ API が正常時はローカル JSON を使わないこと（stale データ混�
 | `/econ-calendar/weekly` | 平日 1日1回（01:00 UTC） | 実績値マージ後に publish。**ポーリング不要** |
 | `/econ-calendar/weekly/meta` | 平日 1日1回（01:00 UTC） | 同上 |
 | `/ranking/*` | publish 時（通常は営業日ごと想定） | market_info の日次バッチ完了後。API は manifest の実内容を正とする |
+| `/ranking-enriched/*` | publish 時（通常は営業日ごと想定） | stock-ranking-enriched が publish された場合 |
 | `/us-ranking/*` | publish 時（通常は営業日ごと想定） | 同上 |
 | `/topix33/*` | publish 時（通常は営業日ごと想定） | 同上 |
 | `/nikkei/*` | publish 時（通常は営業日ごと想定） | 同上 |
@@ -104,6 +105,9 @@ manifest に含まれない日付・月をリクエストした場合、404 が�
 ```
 
 ※ topix33 / nikkei は `latest_date` キーを使う（`latest` ではない）。
+
+`/ranking-enriched/manifest` は `ranking` と同じ `latest` / `dates` shape を返す。
+日次 payload は `/ranking/{date}` と同じ base record fields に、`volumeSpikePct`, `per`, `pbr`, `tickCount`, `upCount`, `downCount`, `marketCapOkuYen`, `dividendYieldPct` を追加する。
 
 ### ranking / topix33 / nikkei の range response
 

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -349,6 +349,48 @@ GET /market-rankings/dividend-yield/monthly/{year_month}    # year_month: YYYY-M
 → （same shape as market-cap monthly）
 ```
 
+### 投資主体別売買動向
+
+```
+GET /investor-flow/latest
+→ {
+    "data_source": "JPX",
+    "source_url": "https://www.jpx.co.jp/markets/statistics-equities/investor-type/...",
+    "source_file": "stock_val_1_260522.xls",
+    "week_label_raw": "2026年5月第3週（5/18 - 5/22）",
+    "start_date": "2026-05-18",
+    "end_date": "2026-05-22",
+    "market_scope": "二市場",
+    "unit": "thousand_yen",
+    "generated_at_jst": "2026-05-28T16:00:00+09:00",
+    "records": [
+      {
+        "row_index": 1,
+        "category": "海外投資家",
+        "sell_thousand_yen": 50000000,
+        "share_sell_pct": null,
+        "buy_thousand_yen": 48000000,
+        "share_buy_pct": null,
+        "diff_thousand_yen": -2000000,
+        "sell_yen": 50000000000,
+        "buy_yen": 48000000000,
+        "diff_yen": -2000000000
+      }
+    ]
+  }
+
+GET /investor-flow/manifest
+→ {
+    "data_source": "JPX",
+    "latest": {"start_date": "2026-05-18", "end_date": "2026-05-22", "path": "investor_flow_2026-05-18_to_2026-05-22.json"},
+    "weeks": [{"start_date": "2026-05-18", "end_date": "2026-05-22", "path": "investor_flow_2026-05-18_to_2026-05-22.json"}],
+    "generated_at_jst": "2026-05-28T16:00:00+09:00"
+  }
+
+GET /investor-flow/weeks/{start_date}/{end_date}    # start_date/end_date: YYYY-MM-DD
+→ （same shape as /investor-flow/latest）
+```
+
 ### EDINET書類一覧
 
 ```
@@ -482,6 +524,8 @@ curl https://market-info-api-619599800912.asia-northeast1.run.app/earnings-calen
 curl https://market-info-api-619599800912.asia-northeast1.run.app/earnings-calendar/overseas/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-rankings/market-cap/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-rankings/dividend-yield/manifest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/investor-flow/latest
+curl https://market-info-api-619599800912.asia-northeast1.run.app/investor-flow/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/edinet/document-list/latest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/tdnet/disclosures/latest
 ```

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -116,6 +116,43 @@ GET /ranking/search?from=2026-03-01&to=2026-03-31&code=7203
   }
 ```
 
+### 株式ランキング enriched
+
+```
+GET /ranking-enriched/manifest
+→ {"dates": ["2026-04-10", ...], "latest": "2026-04-10"}
+
+GET /ranking-enriched/{date}         # date: YYYY-MM-DD
+→ {
+    "date": "2026-04-10",
+    "records": [
+      {
+        "market": "プライム",
+        "ranking": "値上がり率",
+        "rank": 1,
+        "name": "テスト",
+        "code": "1234",
+        "marketLabel": "東証プライム",
+        "industry": "情報・通信業",
+        "price": 1000.0,
+        "time": "15:30",
+        "change": 10.0,
+        "changeRate": 1.0,
+        "volume": 100000.0,
+        "value": 100000000.0,
+        "volumeSpikePct": null,
+        "per": 12.3,
+        "pbr": null,
+        "tickCount": 123.0,
+        "upCount": 80.0,
+        "downCount": 40.0,
+        "marketCapOkuYen": 4567.8,
+        "dividendYieldPct": 2.1
+      }
+    ]
+  }
+```
+
 ### 日経寄与度
 
 ```
@@ -507,6 +544,7 @@ curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/manife
 curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking/2026-03-27
 curl "https://market-info-api-619599800912.asia-northeast1.run.app/ranking/range?from=2026-03-01&to=2026-03-31"
 curl "https://market-info-api-619599800912.asia-northeast1.run.app/ranking/search?from=2026-03-01&to=2026-03-31&code=7203"
+curl https://market-info-api-619599800912.asia-northeast1.run.app/ranking-enriched/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/2026-03-27
 curl "https://market-info-api-619599800912.asia-northeast1.run.app/nikkei/range?from=2026-03-01&to=2026-03-31"

--- a/tests/fixtures/investor_flow_latest_real_shape.json
+++ b/tests/fixtures/investor_flow_latest_real_shape.json
@@ -1,0 +1,37 @@
+{
+  "data_source": "JPX",
+  "source_url": "https://www.jpx.co.jp/markets/statistics-equities/investor-type/nlsgeu0000062rma-att/stock_val_1_260522.xls",
+  "source_file": "stock_val_1_260522.xls",
+  "week_label_raw": "2026年5月第3週（5/18 - 5/22）",
+  "start_date": "2026-05-18",
+  "end_date": "2026-05-22",
+  "market_scope": "二市場",
+  "unit": "thousand_yen",
+  "generated_at_jst": "2026-05-28T16:00:00+09:00",
+  "records": [
+    {
+      "row_index": 1,
+      "category": "総計",
+      "sell_thousand_yen": 123456789,
+      "share_sell_pct": 100.0,
+      "buy_thousand_yen": 124456789,
+      "share_buy_pct": 100.0,
+      "diff_thousand_yen": 1000000,
+      "sell_yen": 123456789000,
+      "buy_yen": 124456789000,
+      "diff_yen": 1000000000
+    },
+    {
+      "row_index": 2,
+      "category": "海外投資家",
+      "sell_thousand_yen": 50000000,
+      "share_sell_pct": null,
+      "buy_thousand_yen": 48000000,
+      "share_buy_pct": null,
+      "diff_thousand_yen": -2000000,
+      "sell_yen": 50000000000,
+      "buy_yen": 48000000000,
+      "diff_yen": -2000000000
+    }
+  ]
+}

--- a/tests/fixtures/investor_flow_manifest_real_shape.json
+++ b/tests/fixtures/investor_flow_manifest_real_shape.json
@@ -1,0 +1,21 @@
+{
+  "data_source": "JPX",
+  "latest": {
+    "start_date": "2026-05-18",
+    "end_date": "2026-05-22",
+    "path": "investor_flow_2026-05-18_to_2026-05-22.json"
+  },
+  "weeks": [
+    {
+      "start_date": "2026-05-18",
+      "end_date": "2026-05-22",
+      "path": "investor_flow_2026-05-18_to_2026-05-22.json"
+    },
+    {
+      "start_date": "2026-05-11",
+      "end_date": "2026-05-15",
+      "path": "investor_flow_2026-05-11_to_2026-05-15.json"
+    }
+  ],
+  "generated_at_jst": "2026-05-28T16:00:00+09:00"
+}

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -27,6 +27,7 @@ def client(monkeypatch):
     import app.routers.tdnet as tdnet_mod
     import app.routers.yutai as yutai_mod
     import app.routers.market_rankings as market_rankings_mod
+    import app.routers.investor_flow as investor_flow_mod
     importlib.reload(earnings_calendar_mod)
     importlib.reload(ranking_mod)
     importlib.reload(nikkei_mod)
@@ -36,6 +37,7 @@ def client(monkeypatch):
     importlib.reload(tdnet_mod)
     importlib.reload(yutai_mod)
     importlib.reload(market_rankings_mod)
+    importlib.reload(investor_flow_mod)
     from app.main import app
     return TestClient(app)
 
@@ -913,3 +915,60 @@ def test_tdnet_disclosures_latest_502(client):
     with patch("app.routers.tdnet.cache.get_manifest", new=AsyncMock(side_effect=err)):
         resp = client.get("/tdnet/disclosures/latest")
     assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# investor-flow
+# ---------------------------------------------------------------------------
+
+
+def test_investor_flow_latest_accepts_market_info_shape(client):
+    payload = _load_fixture("investor_flow_latest_real_shape.json")
+    with patch("app.routers.investor_flow.cache.get_manifest", new=AsyncMock(return_value=payload)):
+        resp = client.get("/investor-flow/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["data_source"] == "JPX"
+    assert data["start_date"] == "2026-05-18"
+    assert data["records"][1]["share_sell_pct"] is None
+    assert data["records"][0]["diff_yen"] == 1000000000
+
+
+def test_investor_flow_manifest_accepts_market_info_shape(client):
+    payload = _load_fixture("investor_flow_manifest_real_shape.json")
+    with patch("app.routers.investor_flow.cache.get_manifest", new=AsyncMock(return_value=payload)):
+        resp = client.get("/investor-flow/manifest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["latest"]["path"] == "investor_flow_2026-05-18_to_2026-05-22.json"
+    assert len(data["weeks"]) == 2
+
+
+def test_investor_flow_week(client):
+    payload = _load_fixture("investor_flow_latest_real_shape.json")
+    with patch("app.routers.investor_flow.cache.get_day", new=AsyncMock(return_value=payload)):
+        resp = client.get("/investor-flow/weeks/2026-05-18/2026-05-22")
+    assert resp.status_code == 200
+    assert resp.json()["end_date"] == "2026-05-22"
+
+
+def test_investor_flow_week_invalid_format(client):
+    resp = client.get("/investor-flow/weeks/20260518/2026-05-22")
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "start_date and end_date must be YYYY-MM-DD format"
+
+
+def test_investor_flow_week_not_found(client):
+    err = _make_http_error("https://r2.example.com/investor-flow/investor_flow_2026-01-05_to_2026-01-09.json", 404)
+    with patch("app.routers.investor_flow.cache.get_day", new=AsyncMock(side_effect=err)):
+        resp = client.get("/investor-flow/weeks/2026-01-05/2026-01-09")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "investor-flow week not found: 2026-01-05 to 2026-01-09"
+
+
+def test_investor_flow_latest_not_found(client):
+    err = _make_http_error("https://r2.example.com/investor-flow/latest.json", 404)
+    with patch("app.routers.investor_flow.cache.get_manifest", new=AsyncMock(side_effect=err)):
+        resp = client.get("/investor-flow/latest")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "investor-flow latest not found"

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -20,6 +20,7 @@ def client(monkeypatch):
     importlib.reload(r2_mod)
     import app.routers.earnings_calendar as earnings_calendar_mod
     import app.routers.ranking as ranking_mod
+    import app.routers.ranking_enriched as ranking_enriched_mod
     import app.routers.nikkei as nikkei_mod
     import app.routers.market_calendar as market_calendar_mod
     import app.routers.sbi as sbi_mod
@@ -30,6 +31,7 @@ def client(monkeypatch):
     import app.routers.investor_flow as investor_flow_mod
     importlib.reload(earnings_calendar_mod)
     importlib.reload(ranking_mod)
+    importlib.reload(ranking_enriched_mod)
     importlib.reload(nikkei_mod)
     importlib.reload(market_calendar_mod)
     importlib.reload(sbi_mod)
@@ -575,6 +577,59 @@ def test_ranking_manifest_502(client):
     with patch("app.routers.ranking.cache.get_manifest", new=AsyncMock(side_effect=err)):
         resp = client.get("/ranking/manifest")
     assert resp.status_code == 502
+
+
+def test_ranking_enriched_manifest(client):
+    manifest = {"dates": ["2026-04-10"], "latest": "2026-04-10"}
+    with patch("app.routers.ranking_enriched.cache.get_manifest", new=AsyncMock(return_value=manifest)):
+        resp = client.get("/ranking-enriched/manifest")
+    assert resp.status_code == 200
+    assert resp.json()["latest"] == "2026-04-10"
+
+
+def test_ranking_enriched_day(client):
+    payload = {
+        "date": "2026-04-10",
+        "records": [
+            {
+                "market": "プライム",
+                "ranking": "値上がり率",
+                "rank": 1,
+                "name": "テスト",
+                "code": "1234",
+                "marketLabel": "東証プライム",
+                "industry": "情報・通信業",
+                "price": 1000.0,
+                "time": "15:30",
+                "change": 10.0,
+                "changeRate": 1.0,
+                "volume": 100000.0,
+                "value": 100000000.0,
+                "volumeSpikePct": None,
+                "per": 12.3,
+                "pbr": None,
+                "tickCount": 123.0,
+                "upCount": 80.0,
+                "downCount": 40.0,
+                "marketCapOkuYen": 4567.8,
+                "dividendYieldPct": 2.1,
+            }
+        ],
+    }
+    with patch("app.routers.ranking_enriched.cache.get_day", new=AsyncMock(return_value=payload)):
+        resp = client.get("/ranking-enriched/2026-04-10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["records"][0]["volumeSpikePct"] is None
+    assert data["records"][0]["marketCapOkuYen"] == 4567.8
+
+
+def test_ranking_enriched_day_not_found(client):
+    err = _make_http_error("https://r2.example.com/stock-ranking-enriched/20260410.json", 404)
+    with patch("app.routers.ranking_enriched.cache.get_day", new=AsyncMock(side_effect=err)):
+        resp = client.get("/ranking-enriched/2026-04-10")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "ranking-enriched not found: 2026-04-10"
 
 
 def test_topix33_day_not_found(client):


### PR DESCRIPTION
## Summary
- add `/investor-flow/latest`, `/investor-flow/manifest`, and `/investor-flow/weeks/{start_date}/{end_date}` endpoints
- model the response shape from `market_info` JPX investor-flow publish artifacts
- document usage/update cadence and add fixture-backed router tests

## Verification
- `.\\.venv\\Scripts\\python.exe -m ruff check .`
- `.\\.venv\\Scripts\\python.exe -m pytest -q`
- `codex review --uncommitted`
