### PR TITLE
Expose investor-flow history matrix

### DIFF
--- a/app/routers/investor_flow.py
+++ b/app/routers/investor_flow.py
@@ -128,6 +128,36 @@ class InvestorFlowMajorFlowItem(BaseModel):
     diff_change_yen: int | None
 
 
+class InvestorFlowHistoryMatrixCell(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    start_date: str | None
+    end_date: str | None
+    buy_yen: int | None
+    sell_yen: int | None
+    diff_yen: int | None
+    direction: str
+    strength: str | None
+
+
+class InvestorFlowHistoryMatrixWeek(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    start_date: str | None
+    end_date: str | None
+    source_snapshot_path: str
+
+
+class InvestorFlowHistoryMatrixRow(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    category: str
+    cells: list[InvestorFlowHistoryMatrixCell]
+
+
+class InvestorFlowHistoryMatrix(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    weeks: list[InvestorFlowHistoryMatrixWeek]
+    rows: list[InvestorFlowHistoryMatrixRow]
+
+
 class InvestorFlowAnalysisSummary(BaseModel):
     model_config = ConfigDict(extra="allow")
     largest_net_buy: InvestorFlowAnalysisCategoryAmount | None
@@ -153,6 +183,7 @@ class InvestorFlowAnalysisPayload(BaseModel):
     reversals: list[InvestorFlowReversalItem]
     streaks: list[InvestorFlowStreakItem]
     major_flows: list[InvestorFlowMajorFlowItem]
+    history_matrix: InvestorFlowHistoryMatrix | None = None
 
 
 @router.get(

--- a/tests/fixtures/investor_flow_analysis_latest_real_shape.json
+++ b/tests/fixtures/investor_flow_analysis_latest_real_shape.json
@@ -106,5 +106,44 @@
       "previous_diff_yen": -100000000000,
       "diff_change_yen": 550000000000
     }
-  ]
+  ],
+  "history_matrix": {
+    "weeks": [
+      {
+        "start_date": "2026-05-18",
+        "end_date": "2026-05-22",
+        "source_snapshot_path": "investor_flow_2026-05-18_to_2026-05-22.json"
+      },
+      {
+        "start_date": "2026-05-11",
+        "end_date": "2026-05-15",
+        "source_snapshot_path": "investor_flow_2026-05-11_to_2026-05-15.json"
+      }
+    ],
+    "rows": [
+      {
+        "category": "海外投資家",
+        "cells": [
+          {
+            "start_date": "2026-05-18",
+            "end_date": "2026-05-22",
+            "buy_yen": 350000000000,
+            "sell_yen": 349550000000,
+            "diff_yen": 450000000000,
+            "direction": "net_buy",
+            "strength": "medium"
+          },
+          {
+            "start_date": "2026-05-11",
+            "end_date": "2026-05-15",
+            "buy_yen": 300000000000,
+            "sell_yen": 300100000000,
+            "diff_yen": -100000000000,
+            "direction": "net_sell",
+            "strength": "medium"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -1039,6 +1039,8 @@ def test_investor_flow_analysis_latest_accepts_market_info_shape(client):
     assert data["summary"]["largest_net_buy"]["category"] == "海外投資家"
     assert data["buy_composition"][0]["share_pct"] == 8.1001
     assert data["reversals"][0]["strength"] == "large"
+    assert data["history_matrix"]["weeks"][0]["start_date"] == "2026-05-18"
+    assert data["history_matrix"]["rows"][0]["cells"][0]["direction"] == "net_buy"
 
 
 def test_investor_flow_analysis_manifest_accepts_market_info_shape(client):


### PR DESCRIPTION
## Summary

- Add `history_matrix` to the investor-flow analysis response model
- Update the real-shape fixture and router assertion so the field is not filtered from API responses

## Verification

- `.\\.venv\\Scripts\\python.exe -m pytest tests/test_routers_unit.py -q`
  - 83 passed
  - 1 pytest cache permission warning
- `codex review --uncommitted`
  - No discrete correctness issues found
