### PR TITLE
feat(api): expose stock master latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /nikko/credit` | 日興証券 信用取引取扱銘柄一覧 |
 | `GET /yutai/manifest` | 優待データ manifest |
 | `GET /yutai/monthly/{year_month}` | 指定月の優待データ |
+| `GET /stock-master/latest` | 銘柄マスター（最新） |
 | `GET /us-ranking/manifest` | 米国株ランキング manifest |
 | `GET /us-ranking/{date}` | 指定日の米国株ランキング JSON |
 | `GET /market-rankings/market-cap/manifest` | 時価総額ランキング manifest |
@@ -102,6 +103,7 @@ curl http://localhost:8000/market-calendar/jpx-closed
 curl http://localhost:8000/market-calendar/us-closed
 curl http://localhost:8000/investor-flow/latest
 curl http://localhost:8000/investor-flow/analysis/latest
+curl http://localhost:8000/stock-master/latest
 ```
 
 ---

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, ranking_enriched, sbi, tdnet, topix33, us_ranking, yutai
+from app.routers import earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, ranking_enriched, sbi, stock_master, tdnet, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -47,6 +47,7 @@ app = FastAPI(
         "| `/nikko/credit` | 不定期 | 可変（6時間） |\n"
         "| `/yutai/manifest` | 月次 | 可変（6時間） |\n"
         "| `/yutai/monthly/{year_month}` | 月次 | 不変（24時間） |\n"
+        "| `/stock-master/latest` | publish 時 | 可変（6時間） |\n"
         "| `/market-calendar/*` | 不定期（年次更新時） | 可変（6時間） |\n"
         "| `/edinet/document-list/latest` | 平日 1日1回 | 可変（6時間） |\n"
         "| `/edinet/document-list/{date}` | 1日1回 | 不変（24時間） |\n"
@@ -68,6 +69,7 @@ app.include_router(nikko.router)
 app.include_router(market_calendar.router)
 app.include_router(topix33.router)
 app.include_router(yutai.router)
+app.include_router(stock_master.router)
 app.include_router(market_rankings.router)
 app.include_router(us_ranking.router)
 app.include_router(edinet.router)

--- a/app/routers/stock_master.py
+++ b/app/routers/stock_master.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/stock-master", tags=["stock-master"])
+
+_LATEST_KEY = "reference/stock-master/latest.json"
+
+
+class StockMasterRecord(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    code: str
+    name: str
+    display_name: str
+    abbrev_name: str
+    short_name2: str | None = None
+    market: str
+    sector: str | None = None
+    is_nikkei225: bool
+    earnings_next_date: str | None = None
+    earnings_next_type: str | None = None
+    earnings_history: str | None = None
+    yutai_months: str | None = None
+    dividend_yield_pct: float | None = None
+    dividend_per_share: int | None = None
+    dividend_as_of: str | None = None
+    as_of_date: str
+
+
+@router.get(
+    "/latest",
+    response_model=list[StockMasterRecord],
+    summary="銘柄マスターの最新スナップショットを取得",
+    responses={
+        404: {"description": "R2 にファイルが存在しない"},
+        502: {"description": "R2 からの取得失敗"},
+    },
+)
+async def get_latest() -> list[dict]:
+    """銘柄マスター latest.json を返す。
+
+    更新単位: stock master publish 時。キャッシュ TTL: 6時間（可変）。
+    mini-tools は銘柄名・市場・決算・優待・配当利回りの基盤情報として利用する。
+    """
+    try:
+        return await cache.get_manifest(
+            "stock-master/latest",
+            lambda: r2.fetch_json(_LATEST_KEY),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(status_code=404, detail="stock master latest not found") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -83,6 +83,7 @@ API が正常時はローカル JSON を使わないこと（stale データ混�
 | `/sbi/credit/*` | 週次 | SBI 信用残高更新に合わせて publish |
 | `/nikko/credit` | 不定期 | 銘柄追加・除外時 |
 | `/yutai/*` | 月次 | 月初に publish |
+| `/stock-master/latest` | publish 時 | 銘柄マスター生成・publish 時。latest-only reference |
 | `/market-rankings/market-cap/*` | 月次 | 月初に publish |
 | `/market-rankings/dividend-yield/*` | 月次 | 月初に publish |
 | `/investor-flow/*` | 週次 | JPX 公式 Excel 掲載後に publish |
@@ -216,6 +217,37 @@ R2 更新時の扱い:
   ]
 }
 ```
+
+### stock-master latest
+
+`/stock-master/latest` は manifest を持たない latest-only reference endpoint。
+`reference/stock-master/latest.json` をそのまま返す。
+
+```json
+[
+  {
+    "code": "7203",
+    "name": "トヨタ自動車",
+    "display_name": "トヨタ自動車",
+    "abbrev_name": "トヨタ",
+    "short_name2": null,
+    "market": "プライム",
+    "sector": "輸送用機器",
+    "is_nikkei225": true,
+    "earnings_next_date": "2026-06-10",
+    "earnings_next_type": "本決算",
+    "earnings_history": "2026-05-08",
+    "yutai_months": null,
+    "dividend_yield_pct": 2.5,
+    "dividend_per_share": 117,
+    "dividend_as_of": "2026-06-07",
+    "as_of_date": "2026-06-08"
+  }
+]
+```
+
+`dividend_per_share` は `market_info` 側で `price×yield/100` から逆算した推定値。
+確定配当金としては扱わない。
 
 ### market-rankings の manifest
 

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -201,6 +201,34 @@ GET /yutai/monthly/{year_month}    # year_month: YYYY-MM
 → {"year": 2026, "month": 12, "records": [...]}
 ```
 
+### 銘柄マスター
+
+```
+GET /stock-master/latest
+→ [
+    {
+      "code": "7203",
+      "name": "トヨタ自動車",
+      "display_name": "トヨタ自動車",
+      "abbrev_name": "トヨタ",
+      "short_name2": null,
+      "market": "プライム",
+      "sector": "輸送用機器",
+      "is_nikkei225": true,
+      "earnings_next_date": "2026-06-10",
+      "earnings_next_type": "本決算",
+      "earnings_history": "2026-05-08",
+      "yutai_months": null,
+      "dividend_yield_pct": 2.5,
+      "dividend_per_share": 117,
+      "dividend_as_of": "2026-06-07",
+      "as_of_date": "2026-06-08"
+    }
+  ]
+```
+
+`dividend_per_share` は推定値。
+
 ### 日興一般信用
 
 ```
@@ -606,6 +634,7 @@ curl https://market-info-api-619599800912.asia-northeast1.run.app/topix33/2026-0
 curl "https://market-info-api-619599800912.asia-northeast1.run.app/topix33/range?from=2026-04-01&to=2026-04-30"
 curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/manifest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/yutai/monthly/2026-12
+curl https://market-info-api-619599800912.asia-northeast1.run.app/stock-master/latest
 curl https://market-info-api-619599800912.asia-northeast1.run.app/nikko/credit
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-calendar/jpx-closed
 curl https://market-info-api-619599800912.asia-northeast1.run.app/market-calendar/us-closed

--- a/tests/fixtures/stock_master_latest_real_shape.json
+++ b/tests/fixtures/stock_master_latest_real_shape.json
@@ -1,0 +1,38 @@
+[
+  {
+    "code": "7203",
+    "name": "トヨタ自動車",
+    "display_name": "トヨタ自動車",
+    "abbrev_name": "トヨタ",
+    "short_name2": null,
+    "market": "プライム",
+    "sector": "輸送用機器",
+    "is_nikkei225": true,
+    "earnings_next_date": "2026-06-10",
+    "earnings_next_type": "本決算",
+    "earnings_history": "2026-05-08,2025-11-07",
+    "yutai_months": null,
+    "dividend_yield_pct": 2.5,
+    "dividend_per_share": 117,
+    "dividend_as_of": "2026-06-07",
+    "as_of_date": "2026-06-08"
+  },
+  {
+    "code": "1301",
+    "name": "極洋",
+    "display_name": "極洋",
+    "abbrev_name": "極洋",
+    "short_name2": null,
+    "market": "プライム",
+    "sector": "水産・農林業",
+    "is_nikkei225": false,
+    "earnings_next_date": null,
+    "earnings_next_type": null,
+    "earnings_history": null,
+    "yutai_months": "3,9",
+    "dividend_yield_pct": null,
+    "dividend_per_share": null,
+    "dividend_as_of": null,
+    "as_of_date": "2026-06-08"
+  }
+]

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -556,6 +556,17 @@ def test_yutai_month(client):
     assert resp.json()["month"] == 3
 
 
+def test_stock_master_latest(client):
+    payload = _load_fixture("stock_master_latest_real_shape.json")
+    with patch("app.routers.stock_master.cache.get_manifest", new=AsyncMock(return_value=payload)):
+        resp = client.get("/stock-master/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["code"] == "7203"
+    assert data[0]["dividend_per_share"] == 117
+    assert data[1]["dividend_yield_pct"] is None
+
+
 # --- 404 / 502 contract tests ---
 
 def _make_http_error(url: str, status: int) -> httpx.HTTPStatusError:
@@ -662,6 +673,14 @@ def test_market_calendar_us_closed_not_found(client):
         resp = client.get("/market-calendar/us-closed")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "us closed calendar not found"
+
+
+def test_stock_master_latest_not_found(client):
+    err = _make_http_error("https://r2.example.com/reference/stock-master/latest.json", 404)
+    with patch("app.routers.stock_master.cache.get_manifest", new=AsyncMock(side_effect=err)):
+        resp = client.get("/stock-master/latest")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "stock master latest not found"
 
 
 def test_nikko_credit(client):


### PR DESCRIPTION
## 概要

R2の銘柄マスターを返すlatest-only APIを追加します。

## 変更内容

- `GET /stock-master/latest`
- 実artifact shapeに沿ったresponse model
- 6時間TTL cacheと404/502契約
- README/API docs/fixture/router testsを追加

## 確認

- `ruff check .`: passed
- `pytest`: 85 passed
- Codex review: actionable findingなし
