### PR TITLE
fix(api): fetch stock master array from R2

### DIFF
--- a/app/r2.py
+++ b/app/r2.py
@@ -25,3 +25,15 @@ async def fetch_json(path: str) -> dict:
     if not isinstance(data, dict):
         raise RuntimeError(f"expected JSON object from {url}, got {type(data).__name__}")
     return data
+
+
+async def fetch_json_array(path: str) -> list:
+    """Fetch a JSON array from an R2 public URL."""
+    url = f"{R2_PUBLIC_BASE_URL}/{path}"
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+    data = resp.json()
+    if not isinstance(data, list):
+        raise RuntimeError(f"expected JSON array from {url}, got {type(data).__name__}")
+    return data

--- a/app/routers/stock_master.py
+++ b/app/routers/stock_master.py
@@ -49,7 +49,7 @@ async def get_latest() -> list[dict]:
     try:
         return await cache.get_manifest(
             "stock-master/latest",
-            lambda: r2.fetch_json(_LATEST_KEY),
+            lambda: r2.fetch_json_array(_LATEST_KEY),
         )
     except Exception as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -567,6 +567,24 @@ def test_stock_master_latest(client):
     assert data[1]["dividend_yield_pct"] is None
 
 
+def test_stock_master_latest_fetches_array_from_r2(client):
+    payload = _load_fixture("stock_master_latest_real_shape.json")
+
+    async def fetch_without_cache(_key, fetch_fn):
+        return await fetch_fn()
+
+    with (
+        patch(
+            "app.routers.stock_master.cache.get_manifest",
+            new=AsyncMock(side_effect=fetch_without_cache),
+        ),
+        patch("app.routers.stock_master.r2.fetch_json_array", new=AsyncMock(return_value=payload)) as fetch,
+    ):
+        resp = client.get("/stock-master/latest")
+    assert resp.status_code == 200
+    fetch.assert_awaited_once_with("reference/stock-master/latest.json")
+
+
 # --- 404 / 502 contract tests ---
 
 def _make_http_error(url: str, status: int) -> httpx.HTTPStatusError:


### PR DESCRIPTION
## 概要

公開 `/stock-master/latest` がR2のトップレベル配列をobjectとして検証し、502になる問題を修正します。

## 変更内容

- R2配列payload専用の `fetch_json_array()` を追加
- stock master routerで配列取得を使用
- cacheを経由した実fetch pathの回帰テストを追加

## 確認

- `ruff check .`: passed
- `pytest`: 86 passed
- Codex review: 指摘なし
- R2 object自体は200、4,451件・配当2,711件を確認済み
