### PR TITLE
feat: expose disclosure event API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ market_info が生成した JSON を mini-tools に提供する薄い API レイ
 | `GET /edinet/document-list/{date}` | 指定日の EDINET 書類一覧 |
 | `GET /tdnet/disclosures/latest` | TDNET 全適時開示一覧（最新） |
 | `GET /tdnet/disclosures/{date}` | 指定日の TDNET 全適時開示一覧 |
+| `GET /disclosure-events/latest` | 正規化済み開示イベント（最新） |
+| `GET /disclosure-events/manifest` | 開示イベント日付一覧 |
+| `GET /disclosure-events/{date}` | 指定日の正規化済み開示イベント |
 | `GET /econ-calendar/weekly` | 今週の経済指標カレンダー |
 | `GET /econ-calendar/weekly/meta` | 経済指標カレンダー更新メタ情報 |
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, ranking_enriched, sbi, stock_master, tdnet, topix33, us_ranking, yutai
+from app.routers import disclosure_events, earnings_calendar, econ_calendar, edinet, health, investor_flow, market_calendar, market_rankings, nikkei, nikko, ranking, ranking_enriched, sbi, stock_master, tdnet, topix33, us_ranking, yutai
 
 app = FastAPI(
     title="market-info-api",
@@ -52,7 +52,9 @@ app = FastAPI(
         "| `/edinet/document-list/latest` | 平日 1日1回 | 可変（6時間） |\n"
         "| `/edinet/document-list/{date}` | 1日1回 | 不変（24時間） |\n"
         "| `/tdnet/disclosures/latest` | 平日 1日1回 | 可変（6時間） |\n"
-        "| `/tdnet/disclosures/{date}` | 1日1回 | 不変（24時間） |\n\n"
+        "| `/tdnet/disclosures/{date}` | 1日1回 | 不変（24時間） |\n"
+        "| `/disclosure-events/latest`, `/manifest` | 平日 1日1回 | 可変（6時間） |\n"
+        "| `/disclosure-events/{date}` | 1日1回 | 不変（24時間） |\n\n"
         "> **ポーリングはデータの更新頻度に基づいて決定すること**（キャッシュ TTL ではなく）。"
         "全データは最短でも 1日1回の更新のため、ポーリング自体が不要なケースがほとんど。"
     ),
@@ -75,4 +77,5 @@ app.include_router(us_ranking.router)
 app.include_router(edinet.router)
 app.include_router(econ_calendar.router)
 app.include_router(tdnet.router)
+app.include_router(disclosure_events.router)
 app.include_router(investor_flow.router)

--- a/app/routers/disclosure_events.py
+++ b/app/routers/disclosure_events.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app import cache, r2
+
+router = APIRouter(prefix="/disclosure-events", tags=["disclosure-events"])
+
+_PREFIX = "disclosure-events"
+_DATE_RE = re.compile(r"^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$")
+
+
+class DisclosureEventItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str
+    source: Literal["tdnet"]
+    event_type: str
+    audience: Literal["all", "personal"]
+    priority: Literal["high", "medium", "low"]
+    needs_review: bool
+    disclosure_date: str
+    disclosure_time: str
+    security_code: str
+    company_name: str
+    title: str
+    disclosure_category: str
+    source_url: str
+    pdf_url: str
+    html_url: str
+    xbrl_url: str
+
+
+class DisclosureEventsPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["disclosure-events-v1"]
+    target_date: str
+    generated_at: str
+    total_count: int
+    items: list[DisclosureEventItem]
+
+
+class DisclosureEventsManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["disclosure-events-manifest-v1"]
+    generated_at: str
+    latest: str
+    dates: list[str]
+
+
+@router.get("/latest", response_model=DisclosureEventsPayload)
+async def get_latest() -> dict:
+    """最新日の正規化済み開示イベントを返す。キャッシュTTL: 6時間。"""
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/latest",
+            lambda: r2.fetch_json(f"{_PREFIX}/latest.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(
+                status_code=404,
+                detail="disclosure events latest not found",
+            ) from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get("/manifest", response_model=DisclosureEventsManifest)
+async def get_manifest() -> dict:
+    """利用可能な日付一覧を返す。キャッシュTTL: 6時間。"""
+    try:
+        return await cache.get_manifest(
+            f"{_PREFIX}/manifest",
+            lambda: r2.fetch_json(f"{_PREFIX}/manifest.json"),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get("/{date}", response_model=DisclosureEventsPayload)
+async def get_by_date(date: str) -> dict:
+    """指定日の正規化済み開示イベントを返す。キャッシュTTL: 24時間。"""
+    if not _DATE_RE.match(date):
+        raise HTTPException(status_code=422, detail="date must be YYYY-MM-DD format")
+    try:
+        return await cache.get_day(
+            f"{_PREFIX}/{date}",
+            lambda: r2.fetch_json(f"{_PREFIX}/{date}.json"),
+        )
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=f"disclosure events not found: {date}",
+            ) from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -80,6 +80,7 @@ API が正常時はローカル JSON を使わないこと（stale データ混�
 | `/earnings-calendar/overseas/*` | 不定期 | 決算データ更新時 |
 | `/edinet/document-list/*` | 平日 1日1回 | 週末・祝日は件数 0 の場合あり |
 | `/tdnet/disclosures/*` | 平日 1日1回 | TDNET 全適時開示一覧。PDF は再配信せず原文 URL を返す |
+| `/disclosure-events/*` | 平日 1日1回 | 保存済みTDNET一覧から生成した優待変更・マイ銘柄向けイベント |
 | `/sbi/credit/*` | 週次 | SBI 信用残高更新に合わせて publish |
 | `/nikko/credit` | 不定期 | 銘柄追加・除外時 |
 | `/yutai/*` | 月次 | 月初に publish |

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -570,6 +570,59 @@ GET /tdnet/disclosures/{date}    # date: YYYY-MM-DD
 → （same shape as /tdnet/disclosures/latest）
 ```
 
+## Disclosure events
+
+```bash
+curl "$MARKET_INFO_API_BASE_URL/disclosure-events/latest"
+curl "$MARKET_INFO_API_BASE_URL/disclosure-events/manifest"
+curl "$MARKET_INFO_API_BASE_URL/disclosure-events/2026-06-12"
+```
+
+`latest` と日付指定は同じレスポンス形式を返す。
+
+```json
+{
+  "schema_version": "disclosure-events-v1",
+  "target_date": "2026-06-12",
+  "generated_at": "2026-06-12T22:00:00+09:00",
+  "total_count": 1,
+  "items": [
+    {
+      "event_id": "tdnet-aaaaaaaaaaaaaaaaaaaa",
+      "source": "tdnet",
+      "event_type": "yutai_end",
+      "audience": "all",
+      "priority": "high",
+      "needs_review": false,
+      "disclosure_date": "2026-06-12",
+      "disclosure_time": "15:30",
+      "security_code": "12340",
+      "company_name": "サンプル",
+      "title": "株主優待制度の廃止に関するお知らせ",
+      "disclosure_category": "株式制度/優待",
+      "source_url": "https://example.com/a.pdf",
+      "pdf_url": "https://example.com/a.pdf",
+      "html_url": "",
+      "xbrl_url": ""
+    }
+  ]
+}
+```
+
+manifest:
+
+```json
+{
+  "schema_version": "disclosure-events-manifest-v1",
+  "generated_at": "2026-06-12T22:00:00+09:00",
+  "latest": "2026-06-12",
+  "dates": ["2026-06-11", "2026-06-12"]
+}
+```
+
+`audience=all` は全銘柄対象の優待変更、`audience=personal` はクライアント側で
+保有・ウォッチコードと照合するイベントを表す。APIへ個人の銘柄コードは送らない。
+
 PDF / HTML / XBRL は再ホストせず、TDNET 原文 URL を返す。
 
 ### JPX休場日

--- a/tests/fixtures/disclosure_events_manifest_real_shape.json
+++ b/tests/fixtures/disclosure_events_manifest_real_shape.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "disclosure-events-manifest-v1",
+  "generated_at": "2026-06-12T22:00:00+09:00",
+  "latest": "2026-06-12",
+  "dates": ["2026-06-11", "2026-06-12"]
+}

--- a/tests/fixtures/disclosure_events_real_shape.json
+++ b/tests/fixtures/disclosure_events_real_shape.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "disclosure-events-v1",
+  "target_date": "2026-06-12",
+  "generated_at": "2026-06-12T22:00:00+09:00",
+  "total_count": 2,
+  "items": [
+    {
+      "event_id": "tdnet-aaaaaaaaaaaaaaaaaaaa",
+      "source": "tdnet",
+      "event_type": "yutai_end",
+      "audience": "all",
+      "priority": "high",
+      "needs_review": false,
+      "disclosure_date": "2026-06-12",
+      "disclosure_time": "15:30",
+      "security_code": "12340",
+      "company_name": "サンプル",
+      "title": "株主優待制度の廃止に関するお知らせ",
+      "disclosure_category": "株式制度/優待",
+      "source_url": "https://example.com/a.pdf",
+      "pdf_url": "https://example.com/a.pdf",
+      "html_url": "",
+      "xbrl_url": ""
+    },
+    {
+      "event_id": "tdnet-bbbbbbbbbbbbbbbbbbbb",
+      "source": "tdnet",
+      "event_type": "dividend_decrease",
+      "audience": "personal",
+      "priority": "high",
+      "needs_review": false,
+      "disclosure_date": "2026-06-12",
+      "disclosure_time": "15:00",
+      "security_code": "56780",
+      "company_name": "配当サンプル",
+      "title": "配当予想の修正（減配）に関するお知らせ",
+      "disclosure_category": "業績・配当予想/配当",
+      "source_url": "https://example.com/b.pdf",
+      "pdf_url": "https://example.com/b.pdf",
+      "html_url": "",
+      "xbrl_url": ""
+    }
+  ]
+}

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -26,6 +26,7 @@ def client(monkeypatch):
     import app.routers.sbi as sbi_mod
     import app.routers.topix33 as topix33_mod
     import app.routers.tdnet as tdnet_mod
+    import app.routers.disclosure_events as disclosure_events_mod
     import app.routers.yutai as yutai_mod
     import app.routers.market_rankings as market_rankings_mod
     import app.routers.investor_flow as investor_flow_mod
@@ -37,11 +38,14 @@ def client(monkeypatch):
     importlib.reload(sbi_mod)
     importlib.reload(topix33_mod)
     importlib.reload(tdnet_mod)
+    importlib.reload(disclosure_events_mod)
     importlib.reload(yutai_mod)
     importlib.reload(market_rankings_mod)
     importlib.reload(investor_flow_mod)
-    from app.main import app
-    return TestClient(app)
+    import app.main as main_mod
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as test_client:
+        yield test_client
 
 
 _FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -1007,6 +1011,78 @@ def test_tdnet_disclosures_latest_502(client):
     with patch("app.routers.tdnet.cache.get_manifest", new=AsyncMock(side_effect=err)):
         resp = client.get("/tdnet/disclosures/latest")
     assert resp.status_code == 502
+
+
+# disclosure events
+
+
+def test_disclosure_events_latest_accepts_real_shape(client):
+    from app.routers import disclosure_events
+
+    payload = _load_fixture("disclosure_events_real_shape.json")
+    with patch.object(
+        disclosure_events.cache,
+        "get_manifest",
+        new=AsyncMock(return_value=payload),
+    ):
+        resp = client.get("/disclosure-events/latest")
+
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["event_type"] == "yutai_end"
+
+
+def test_disclosure_events_manifest_accepts_real_shape(client):
+    from app.routers import disclosure_events
+
+    payload = _load_fixture("disclosure_events_manifest_real_shape.json")
+    with patch.object(
+        disclosure_events.cache,
+        "get_manifest",
+        new=AsyncMock(return_value=payload),
+    ):
+        resp = client.get("/disclosure-events/manifest")
+
+    assert resp.status_code == 200
+    assert resp.json()["latest"] == "2026-06-12"
+
+
+def test_disclosure_events_by_date(client):
+    from app.routers import disclosure_events
+
+    payload = _load_fixture("disclosure_events_real_shape.json")
+    with patch.object(
+        disclosure_events.cache,
+        "get_day",
+        new=AsyncMock(return_value=payload),
+    ):
+        resp = client.get("/disclosure-events/2026-06-12")
+
+    assert resp.status_code == 200
+    assert resp.json()["total_count"] == 2
+
+
+def test_disclosure_events_by_date_invalid_format(client):
+    resp = client.get("/disclosure-events/20260612")
+    assert resp.status_code == 422
+
+
+def test_disclosure_events_latest_not_found(client):
+    from app.routers import disclosure_events
+
+    err = _make_http_error(
+        "https://r2.example.com/disclosure-events/latest.json",
+        404,
+    )
+    with patch.object(
+        disclosure_events.cache,
+        "get_manifest",
+        new=AsyncMock(side_effect=err),
+    ):
+        resp = client.get("/disclosure-events/latest")
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "disclosure events latest not found"
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `/disclosure-events/latest`, `/manifest`, and `/{date}`
- validate the disclosure event and manifest response contracts
- preserve 404 for unpublished latest/date artifacts
- document curl and response examples

## Verification

- full pytest: 91 passed
- `ruff check .`: passed
- Codex review findings were addressed

## Dependency

- consumes artifacts produced by `market_info` branch `feature/disclosure-event-radar`
