### PR TITLE
Add browser caching for disclosure history

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -9,6 +9,9 @@ from cachetools import TTLCache
 _MANIFEST_TTL = 21600   # 6時間（可変データ）
 _DAY_TTL = 86400        # 24時間（不変データ）
 
+MUTABLE_HTTP_CACHE_CONTROL = "public, max-age=300"
+IMMUTABLE_HTTP_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
 _manifest_cache: TTLCache = TTLCache(maxsize=16, ttl=_MANIFEST_TTL)
 _day_cache: TTLCache = TTLCache(maxsize=128, ttl=_DAY_TTL)
 _range_current_cache: TTLCache = TTLCache(maxsize=64, ttl=_MANIFEST_TTL)

--- a/app/routers/disclosure_events.py
+++ b/app/routers/disclosure_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel, ConfigDict
 
 from app import cache, r2
@@ -55,8 +55,9 @@ class DisclosureEventsManifest(BaseModel):
 
 
 @router.get("/latest", response_model=DisclosureEventsPayload)
-async def get_latest() -> dict:
+async def get_latest(response: Response) -> dict:
     """最新日の正規化済み開示イベントを返す。キャッシュTTL: 6時間。"""
+    response.headers["Cache-Control"] = cache.MUTABLE_HTTP_CACHE_CONTROL
     try:
         return await cache.get_manifest(
             f"{_PREFIX}/latest",
@@ -73,8 +74,9 @@ async def get_latest() -> dict:
 
 
 @router.get("/manifest", response_model=DisclosureEventsManifest)
-async def get_manifest() -> dict:
+async def get_manifest(response: Response) -> dict:
     """利用可能な日付一覧を返す。キャッシュTTL: 6時間。"""
+    response.headers["Cache-Control"] = cache.MUTABLE_HTTP_CACHE_CONTROL
     try:
         return await cache.get_manifest(
             f"{_PREFIX}/manifest",
@@ -85,10 +87,11 @@ async def get_manifest() -> dict:
 
 
 @router.get("/{date}", response_model=DisclosureEventsPayload)
-async def get_by_date(date: str) -> dict:
+async def get_by_date(date: str, response: Response) -> dict:
     """指定日の正規化済み開示イベントを返す。キャッシュTTL: 24時間。"""
     if not _DATE_RE.match(date):
         raise HTTPException(status_code=422, detail="date must be YYYY-MM-DD format")
+    response.headers["Cache-Control"] = cache.IMMUTABLE_HTTP_CACHE_CONTROL
     try:
         return await cache.get_day(
             f"{_PREFIX}/{date}",

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -451,6 +451,18 @@ TTL はデータの**可変性**によって 2 種類に分ける。TTL はサ�
 
 > この TTL 設計は market_info の publish スケジュールに依存する。**最短更新間隔が 24時間未満に変わった場合は TTL を合わせて見直すこと**。設計ルールの正本は `market_info/docs/reference/policy_decision_rules.md` を参照。
 
+上表はCloud Runプロセス内キャッシュのTTLであり、HTTPレスポンスキャッシュとは別レイヤー。
+開示イベントでは次のHTTP `Cache-Control`を返す。
+
+| Endpoint | HTTP Cache-Control | 理由 |
+|---|---|---|
+| `/disclosure-events/{date}` | `public, max-age=31536000, immutable` | 日付別artifactはpublish後に変更しない |
+| `/disclosure-events/manifest` | `public, max-age=300` | 新しい日付の追加を5分以内に確認する |
+| `/disclosure-events/latest` | `public, max-age=300` | 次回publishで参照先内容が変わる |
+
+ブラウザキャッシュは通信量削減の補助であり、永続保存先ではない。端末やブラウザが
+キャッシュを削除した場合は同じ日付別endpointを再取得すればよい。
+
 TTL の実装値は `app/cache.py` の `_MANIFEST_TTL`（21600秒）/ `_DAY_TTL`（86400秒）を参照。
 range response は latest/current period を含む場合 `_MANIFEST_TTL`、過去 immutable source のみの場合 `_DAY_TTL` を使う。
 search index も同じ TTL 方針を使う。

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -623,6 +623,16 @@ manifest:
 `audience=all` は全銘柄対象の優待変更、`audience=personal` はクライアント側で
 保有・ウォッチコードと照合するイベントを表す。APIへ個人の銘柄コードは送らない。
 
+Cache headers:
+
+- `GET /disclosure-events/{date}`:
+  `Cache-Control: public, max-age=31536000, immutable`
+- `GET /disclosure-events/manifest` and `GET /disclosure-events/latest`:
+  `Cache-Control: public, max-age=300`
+
+日付別レスポンスは不変のため、ブラウザやCDNが長期再利用できる。manifestは短期確認し、
+新しく追加された日付だけを取得する。
+
 PDF / HTML / XBRL は再ホストせず、TDNET 原文 URL を返す。
 
 ### JPX休場日

--- a/tests/test_routers_unit.py
+++ b/tests/test_routers_unit.py
@@ -1029,6 +1029,7 @@ def test_disclosure_events_latest_accepts_real_shape(client):
 
     assert resp.status_code == 200
     assert resp.json()["items"][0]["event_type"] == "yutai_end"
+    assert resp.headers["cache-control"] == "public, max-age=300"
 
 
 def test_disclosure_events_manifest_accepts_real_shape(client):
@@ -1044,6 +1045,7 @@ def test_disclosure_events_manifest_accepts_real_shape(client):
 
     assert resp.status_code == 200
     assert resp.json()["latest"] == "2026-06-12"
+    assert resp.headers["cache-control"] == "public, max-age=300"
 
 
 def test_disclosure_events_by_date(client):
@@ -1059,6 +1061,10 @@ def test_disclosure_events_by_date(client):
 
     assert resp.status_code == 200
     assert resp.json()["total_count"] == 2
+    assert (
+        resp.headers["cache-control"]
+        == "public, max-age=31536000, immutable"
+    )
 
 
 def test_disclosure_events_by_date_invalid_format(client):


### PR DESCRIPTION
## Summary

- document the disclosure browser cache contract
- return short cache headers for mutable manifest/latest responses
- return one-year immutable cache headers for dated disclosure JSON

## Verification

- API test suite: 91 passed
- Ruff checks passed
- Codex review: no findings

## Related

- Depends on dated JSON immutability in `market_info`
